### PR TITLE
Add cd commands to build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ git submodule update
 ````
 cd darling
 mkdir -p build/x86-64
+cd build/x86-64
 cmake ../.. -DCMAKE_TOOLCHAIN_FILE=../../Toolchain-x86_64.cmake
 make
 make install
@@ -55,6 +56,7 @@ Required dependencies on Debian (stable): cmake clang bison flex linux-headers-a
 ````
 cd darling
 mkdir -p build/i386
+cd build/x86-64
 cmake ../.. -DCMAKE_TOOLCHAIN_FILE=../../Toolchain-x86.cmake
 make
 make install

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Required dependencies on Debian (stable): cmake clang bison flex linux-headers-a
 ````
 cd darling
 mkdir -p build/i386
-cd build/x86-64
+cd build/i386
 cmake ../.. -DCMAKE_TOOLCHAIN_FILE=../../Toolchain-x86.cmake
 make
 make install


### PR DESCRIPTION
I was confused for a while when I tried to build Darling because I ran cmake from the wrong directory. I know that it's reasonably intuitive (I did, after all, figure it out), but I thought I'd spare others from this particular hiccup.