### PR TITLE
Darling should set its own PATH

### DIFF
--- a/src/dyld/darling
+++ b/src/dyld/darling
@@ -18,6 +18,8 @@
 # along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 # 
 
+export PATH="/bin:/usr/bin"
+
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 DARLING_PREFIX=$(realpath "$SCRIPTPATH/..")


### PR DESCRIPTION
This is a minor issue which occurred on Arch Linux (FHS is not standard, there is not /bin...).

The default PATH on Arch is:
```
$ echo $PATH      
/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
```

Without this patch:
```
$ darling shell
Darling [~]$ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
Darling [~]$ ls $DPREFIX
bash: ls: command not found
Darling [~]$ /bin/ls $DPREFIX
Applications	Volumes		dev		private		usr
System		bin		etc		system-root	var
Users		darling-prefix	home		tmp
```

With this patch:
```
Darling [~]$ echo $PATH
/bin:/usr/bin
Darling [~]$ ls $DPREFIX
Applications	Volumes		dev		private		usr
System		bin		etc		system-root	var
Users		darling-prefix	home		tmp
```