### PR TITLE
Fix timestamp check in darling script (see #134)

### DIFF
--- a/src/dyld/darling
+++ b/src/dyld/darling
@@ -33,8 +33,8 @@ check_prefix() {
     else
 
         updatets=$(cat $DPREFIX/.update-timestamp)
-        if [ "$updatets" != "disable" -a "$updatets" -lt $selfmtime ]; then
-            setup_prefix "$DPREFIX"
+        if [ "$updatets" != "disable" -a "$updatets" != "disabled" ]; then
+            [ $updatets -lt $selfmtime ] && setup_prefix "$DPREFIX"
         fi
     fi
 }


### PR DESCRIPTION
When I put "disable" or "disabled" in $DPREFIX/.update-timestamp, I've got one error.
Sh doesn't like to compare a string with an integer.