### PR TITLE
Fix unexistent -r git option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that no GUI applications are supported at the moment.
 Darling uses many Git submodules, so a plain clone will not do.
 
 ````
-git clone -r https://github.com/darlinghq/darling.git
+git clone --recurse-submodules https://github.com/darlinghq/darling.git
 ````
 
 Updating sources:


### PR DESCRIPTION
During the very first try, I had the following troubles
```bash
andrew:$ git clone -r https://github.com/darlinghq/darling.git
error: unknown switch `r'
```
Replacing it with --recurse-submodules helped.

```bash
andrew:$ git clone --recurse-submodules  https://github.com/darlinghq/darling.git
Cloning into 'darling'...
remote: Counting objects: 27092, done.
remote: Compressing objects: 100% (199/199), done.
remote: Total 27092 (delta 95), reused 0 (delta 0), pack-reused 26885
Receiving objects: 100% (27092/27092), 21.98 MiB | 7.51 MiB/s, done.
Resolving deltas: 100% (13754/13754), done.
Checking connectivity... done.
# tens of submodules clones here
```
```bash
andrew:$ git --version
git version 1.9.1
```