### PR TITLE
Changes needed to build on Debian system

### DIFF
--- a/src/launchd/support/launchctl.c
+++ b/src/launchd/support/launchctl.c
@@ -72,7 +72,8 @@
 #include <dns_sd.h>
 #include <paths.h>
 #include <utmpx.h>
-#include <bootfiles.h>
+#include <signal.h>
+#include <ctype.h>
 #include <sysexits.h>
 #include <util.h>
 #include <spawn.h>


### PR DESCRIPTION
Note ``bootfiles.h`` is an OSX file not current found in darling or any of its submodules.