### PR TITLE
add build dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ For complete instructions, visit [DarlingHQ.org](http://www.darlinghq.org/build-
 <img src="http://teamcity.dolezel.info/app/rest/builds/buildType:(id:Darling_DebianStableX8664)/statusIcon" title="Debian stable build for x86-64"/>
 </a>
 
+Required dependencies
+
+Debian (stable):
+
+```
+$ sudo apt-get install cmake clang bison flex xz-utils libfuse-dev libxml2-dev libicu-dev libssl-dev libbz2-dev zlib1g-dev libudev-dev linux-headers-amd64
+```
+
+Ubuntu (16.04):
+
+```
+$ sudo apt-get install cmake clang bison flex xz-utils libfuse-dev libxml2-dev libicu-dev libssl-dev libbz2-dev zlib1g-dev libudev-dev linux-headers-generic
+```
+
+Arch Linux (4.8):
+
+```
+$ sudo pacman -S cmake clang flex icu fuse
+```
+
 ````
 cd darling
 mkdir -p build/x86-64
@@ -49,6 +69,20 @@ make install
 <a href="http://teamcity.dolezel.info/viewType.html?buildTypeId=Darling_DebianStableX8664&guest=1">
 <img src="http://teamcity.dolezel.info/app/rest/builds/buildType:(id:Darling_DebianStableX8664)/statusIcon" title="Debian stable build for i386"/>
 </a>
+
+Required additional dependencies (on top of x86_64 dependencies)
+
+Debian (stable) / Ubuntu (15.10):
+
+```
+$ sudo apt-get install libc6-dev-i386 libudev-dev:i386 lib32stdc++-4.9-dev
+```
+
+Arch Linux (4.8):
+
+```
+$ sudo pacman -S lib32-libstdc++5 lib32-clang
+```
 
 ````
 cd darling


### PR DESCRIPTION
Could the added arch linux dependencies perhaps also be added to the website? I couldn't seem to find the repository for the website, otherwise I would have helped out with that.

For now I can't build the i386 build on Arch Linux (x64) though, as I get stuck at the following during `make`:

```
$ make
[  0%] Built target migcom
[  0%] Built target system_duct
[  4%] Built target emulation
[  4%] Building C object src/kernel/libsyscall/CMakeFiles/libsyscall.dir/custom/errno.o
/tmp/errno-4a1da7.s: Assembler messages:
/tmp/errno-4a1da7.s:630: Error: inconsistent uses of .cfi_sections
clang-3.9: error: assembler command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/kernel/libsyscall/CMakeFiles/libsyscall.dir/build.make:1611: src/kernel/libsyscall/CMakeFiles/libsyscall.dir/custom/errno.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:515: src/kernel/libsyscall/CMakeFiles/libsyscall.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
```