### PR TITLE
kernel module: added initial dkms support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ cd build/x86-64
 cmake ../.. -DCMAKE_TOOLCHAIN_FILE=../../Toolchain-x86_64.cmake
 make
 make install
-
-# Now we go into src/lkm to build the kernel module
-cd ../../src/lkm
-make
-make install
 ````
 
 #### For running i386 OS X binaries
@@ -91,6 +86,23 @@ cd build/i386
 cmake ../.. -DCMAKE_TOOLCHAIN_FILE=../../Toolchain-x86.cmake
 make
 make install
+````
+
+#### Building and loading the kernel module (x86-64 and i386)
+
+````
+# Go into src/lkm to build the kernel module
+cd ../../src/lkm
+make
+make install
+````
+
+If this does not work (e.g. on newer Ubuntu versions), try the DKMS build:
+
+````
+# Go into src/lkm to build the kernel module
+cd ../../src/lkm
+sudo ./dkms.sh
 ````
 
 Loading the kernel module:

--- a/src/lkm/Makefile
+++ b/src/lkm/Makefile
@@ -1,6 +1,8 @@
-ccflags-y := -I$(src)/../../kernel-include \
-		-I$(src)/../../platform-include \
-		-I$(src)/../libc/include \
+DARLING_SRC ?= $(src)
+
+ccflags-y := -I$(DARLING_SRC)/../../kernel-include \
+		-I$(DARLING_SRC)/../../platform-include \
+		-I$(DARLING_SRC)/../libc/include \
 		-DMACH_KERNEL_PRIVATE \
 		-DDARLING_DEBUG \
 		-D__LITTLE_ENDIAN__ \
@@ -32,7 +34,11 @@ else
 	PWD := $(shell pwd)
 default:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
 endif
+
+all:
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
 clean:
 	rm -f *.o *.ko

--- a/src/lkm/dkms.conf
+++ b/src/lkm/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="darling-mach"
+PACKAGE_VERSION="1.0"
+CLEAN="make clean"
+MAKE[0]="make all KVERSION=$kernelver"
+BUILT_MODULE_NAME[0]="darling-mach"
+DEST_MODULE_LOCATION[0]="/updates"
+AUTOINSTALL="yes"

--- a/src/lkm/dkms.sh
+++ b/src/lkm/dkms.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+export DARLING_SRC=`pwd`
+dkms add .
+dkms build -m darling-mach -v 1.0
+dkms install -m darling-mach -v 1.0
+

--- a/src/lkm/remove_dkms.sh
+++ b/src/lkm/remove_dkms.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+dkms remove -m darling-mach -v 1.0 --all
+rm -rf /var/lib/dkms/darling-mach
+rm -rf /usr/src/darling-mach-1.0
+


### PR DESCRIPTION
This was tested on Ubuntu 16.04. I do not have a system where the "old" way works, so someone should test if it still works with the Makefile changes.