### PR TITLE
Build the manpage database when the prefix is set up

### DIFF
--- a/src/dyld/darling
+++ b/src/dyld/darling
@@ -99,6 +99,9 @@ setup_prefix() {
 
     install_pkg "org.darlinghq.pkg.OpenSSLCertificates"
 
+    >&2 echo "Building manpage database..."
+    exec "${dexec_path}" "${DPREFIX}/bin/bash" -c "/usr/libexec/makewhatis"
+
     >&2 echo "Prefix is ready."
 }
 

--- a/src/dyld/darling
+++ b/src/dyld/darling
@@ -52,7 +52,7 @@ setup_prefix() {
     prefix_pkg="/tmp/prefix.$$.pkg"
 
     >&2 echo "Setting up prefix at $1"
-    >&2 echo 
+    >&2 echo
 
     mkdir -p "$1"
     rm -f "$1/darling-prefix"
@@ -83,7 +83,7 @@ setup_prefix() {
     ln -sf "../system-root/etc/group" "$1/etc/group"
     ln -sf "../system-root/etc/hosts" "$1/etc/hosts"
     ln -sf "../system-root/etc/localtime" "$1/etc/localtime" || true
-    
+
     mkdir -p "$1/usr/share"
 	rm -f "$1/usr/share/zoneinfo" 2>/dev/null || true
     ln -sf "../../system-root/usr/share/zoneinfo" "$1/usr/share/zoneinfo"
@@ -100,7 +100,7 @@ setup_prefix() {
     install_pkg "org.darlinghq.pkg.OpenSSLCertificates"
 
     >&2 echo "Building manpage database..."
-    exec "${dexec_path}" "${DPREFIX}/bin/bash" -c "/usr/libexec/makewhatis"
+    "${dexec_path}" "${DPREFIX}/bin/bash" -c "/usr/libexec/makewhatis"
 
     >&2 echo "Prefix is ready."
 }


### PR DESCRIPTION
A step to `setup_prefix` in `src/dyld/darling` that runs the script to build the manpage database. 

The manpage database (stored in `/usr/share/man/whatis`) is used by commands that search manpages, such as `apropos` and `whatis`. 