### PR TITLE
Add a submodule for OpenSSL Certificates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -180,3 +180,6 @@
 [submodule "src/external/bc"]
 	path = src/external/bc
 	url = ../darling-bc.git
+[submodule "src/external/openssl_certificates"]
+	path = src/external/openssl_certificates
+	url = ../darling-openssl_certificates.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ add_subdirectory(sandbox)
 add_subdirectory(Cocoa)
 add_subdirectory(external/file/file)
 add_subdirectory(external/libxpc)
+add_subdirectory(external/openssl_certificates)
 
 if (NOT DARLING_NO_EXECUTABLES)
 	add_subdirectory(external/shell_cmds)


### PR DESCRIPTION
Related to #197.
It adds a submodule with OpenSSL Certificates.

OpenSSL Certificates are installed in `${CMAKE_INSTALL_PREFIX}/libexec/darling/System/Library/OpenSSL/certs`.
Symbolic links are created by CMakeLists.txt.

PS: I'm sorry, I'm not sure of way to add submodules. Tell me if I'm wrong.