### PR TITLE
Put some top-level dirs into /private and install symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,13 @@ option(FRAMEWORK_APPKIT "Enable AppKit development code" OFF)
 add_subdirectory(src)
 
 if (NOT DARLING_NO_EXECUTABLES)
+	install(DIRECTORY DESTINATION libexec/darling/private)
+	install(DIRECTORY DESTINATION libexec/darling/private/etc)
+	install(DIRECTORY DESTINATION libexec/darling/private/var)
+	InstallSymlink(private/etc ${CMAKE_INSTALL_PREFIX}/libexec/darling/etc)
+	InstallSymlink(private/var ${CMAKE_INSTALL_PREFIX}/libexec/darling/var)
+	InstallSymlink(private/tmp ${CMAKE_INSTALL_PREFIX}/libexec/darling/tmp)
+
 	install(FILES etc/dylib.conf etc/version.conf
 		DESTINATION libexec/darling/etc/darling)
 	install(FILES etc/resolv.conf
@@ -67,7 +74,6 @@ if (NOT DARLING_NO_EXECUTABLES)
 
 	install(DIRECTORY DESTINATION libexec/darling/proc)
 
-	install(DIRECTORY DESTINATION libexec/darling/var)
 	install(DIRECTORY DESTINATION libexec/darling/var/root)
 	install(DIRECTORY DESTINATION libexec/darling/var/run)
 	InstallSymlink(/dev/log ${CMAKE_INSTALL_PREFIX}/libexec/darling/var/run/syslog)
@@ -78,7 +84,7 @@ if (NOT DARLING_NO_EXECUTABLES)
 	InstallSymlink(/Volumes/SystemRoot${CMAKE_INSTALL_PREFIX}/share/darling ${CMAKE_INSTALL_PREFIX}/libexec/darling/usr/local/share/darling)
 
 	InstallSymlink(/Volumes/SystemRoot/dev ${CMAKE_INSTALL_PREFIX}/libexec/darling/dev)
-	InstallSymlink(/Volumes/SystemRoot/tmp ${CMAKE_INSTALL_PREFIX}/libexec/darling/tmp)
+	InstallSymlink(/Volumes/SystemRoot/tmp ${CMAKE_INSTALL_PREFIX}/libexec/darling/private/tmp)
 	InstallSymlink(/Volumes/SystemRoot/home ${CMAKE_INSTALL_PREFIX}/libexec/darling/Users)
 
 	InstallSymlink(/proc/self/mounts ${CMAKE_INSTALL_PREFIX}/libexec/darling/etc/mtab)

--- a/src/dyld/darling.c
+++ b/src/dyld/darling.c
@@ -619,12 +619,20 @@ void setupPrefix()
 	snprintf(path, sizeof(path), "%s/Applications", prefix);
 	createDir(path);
 
-	// ... and to put stuff in /usr/local
+	// ... to put stuff in /usr/local,
 	snprintf(path, sizeof(path), "%s/usr", prefix);
 	createDir(path);
 	snprintf(path, sizeof(path), "%s/usr/local", prefix);
 	createDir(path);
 	snprintf(path, sizeof(path), "%s/usr/local/share", prefix);
+	createDir(path);
+
+	// ... and to install plists to /var/db
+	snprintf(path, sizeof(path), "%s/private", prefix);
+	createDir(path);
+	snprintf(path, sizeof(path), "%s/private/var", prefix);
+	createDir(path);
+	snprintf(path, sizeof(path), "%s/private/var/db", prefix);
 	createDir(path);
 
 	seteuid(0);


### PR DESCRIPTION
On macOS:

```
/tmp -> private/tmp
/var -> private/var
/etc -> private/etc
```

and some apps may depend on it (as [this answer](https://apple.stackexchange.com/questions/1043/why-is-tmp-a-symlink-to-private-tmp) mentions). Let's do the same on Darling.

Specifically, `installer` (or installation scripts) wanted to write to `/private/var/db` -- so this should work now.