### PR TITLE
Fix libs installation

### DIFF
--- a/Toolchain-x86.cmake
+++ b/Toolchain-x86.cmake
@@ -7,8 +7,7 @@ SET(CMAKE_CXX_COMPILER clang++)
 SET(BITS 32)
 
 if (EXISTS "/etc/debian_version")
-	SET (CMAKE_INSTALL_LIBDIR "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+	SET (CMAKE_INSTALL_LIBDIR "lib/i386-linux-gnu")
 else (EXISTS "/etc/debian_version")
 	SET (CMAKE_INSTALL_LIBDIR "lib32")
 endif (EXISTS "/etc/debian_version")
-

--- a/Toolchain-x86_64.cmake
+++ b/Toolchain-x86_64.cmake
@@ -6,8 +6,7 @@ SET(CMAKE_CXX_COMPILER clang++)
 SET(BITS 64)
 
 if (EXISTS "/etc/debian_version")
-	SET (CMAKE_INSTALL_LIBDIR "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+	SET (CMAKE_INSTALL_LIBDIR "lib/x86_64-linux-gnu")
 else (EXISTS "/etc/debian_version")
 	SET (CMAKE_INSTALL_LIBDIR "lib64")
 endif (EXISTS "/etc/debian_version")
-

--- a/src/dyld/darling.c
+++ b/src/dyld/darling.c
@@ -272,7 +272,7 @@ void setupChild(const char *curPath)
 		1);
 
 	setenv("LD_LIBRARY_PATH",
-		SYSTEM_ROOT LIB_PATH,
+		SYSTEM_ROOT LIB_PATH ":" SYSTEM_ROOT INSTALL_PREFIX "/lib/i386-linux-gnu/darling",
 		1);
 
 	sscanf(getenv("HOME"), "/home/%4096s", buffer1);


### PR DESCRIPTION
Suggested temporary fix for #231 -- hardcoding architectures in `Toolcain-*.cmake` files and passing half-hardcoded i386 lib path in `LD_LIBRARY_PATH`.