### PR TITLE
Fixes for setup-ld-so.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(InstallSymlink)
 
 set(DARLING_TOP_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+set(LD_SO_CONF_DIRECTORY "${CMAKE_BINARY_DIR}/etc/ld.so.conf.d")
 set(DARLING_NO_EXECUTABLES OFF)
 set(CMAKE_C_IMPLICIT_LINK_LIBRARIES "")
 set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
@@ -38,10 +39,15 @@ InstallSymlink(private/etc ${CMAKE_INSTALL_PREFIX}/libexec/darling/etc)
 InstallSymlink(private/var ${CMAKE_INSTALL_PREFIX}/libexec/darling/var)
 InstallSymlink(private/tmp ${CMAKE_INSTALL_PREFIX}/libexec/darling/tmp)
 
+file(MAKE_DIRECTORY ${LD_SO_CONF_DIRECTORY})
+execute_process(COMMAND bash ${DARLING_TOP_DIRECTORY}/src/setup-ld-so.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
 install(FILES etc/dylib.conf etc/version.conf
 	DESTINATION libexec/darling/etc/darling)
-install(FILES etc/resolv.conf
+install(FILES etc/resolv.conf ${CMAKE_BINARY_DIR}/etc/ld.so.conf
 	DESTINATION libexec/darling/etc)
+install(DIRECTORY ${LD_SO_CONF_DIRECTORY}
+	DESTINATION libexec/darling/etc/ld.so.conf.d)
 
 install(DIRECTORY DESTINATION libexec/darling/Volumes)
 install(DIRECTORY DESTINATION libexec/darling/Volumes/SystemRoot)
@@ -68,8 +74,6 @@ InstallSymlink(/Volumes/SystemRoot/etc/passwd ${CMAKE_INSTALL_PREFIX}/libexec/da
 InstallSymlink(/Volumes/SystemRoot/etc/group ${CMAKE_INSTALL_PREFIX}/libexec/darling/etc/group)
 InstallSymlink(/Volumes/SystemRoot/etc/localtime ${CMAKE_INSTALL_PREFIX}/libexec/darling/etc/localtime)
 
-install(DIRECTORY DESTINATION libexec/darling/etc/ld.so.conf.d)
-install(CODE "execute_process(COMMAND bash ${DARLING_TOP_DIRECTORY}/src/setup-ld-so.sh WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/libexec/darling)")
 InstallSymlink(/Volumes/SystemRoot/lib ${CMAKE_INSTALL_PREFIX}/libexec/darling/lib)
 InstallSymlink(/Volumes/SystemRoot/lib64 ${CMAKE_INSTALL_PREFIX}/libexec/darling/lib64)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ InstallSymlink(private/var ${CMAKE_INSTALL_PREFIX}/libexec/darling/var)
 InstallSymlink(private/tmp ${CMAKE_INSTALL_PREFIX}/libexec/darling/tmp)
 
 file(MAKE_DIRECTORY ${LD_SO_CONF_DIRECTORY})
-execute_process(COMMAND bash ${DARLING_TOP_DIRECTORY}/src/setup-ld-so.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+execute_process(COMMAND bash ${DARLING_TOP_DIRECTORY}/src/setup-ld-so.sh ${CMAKE_BINARY_DIR})
 
 install(FILES etc/dylib.conf etc/version.conf
 	DESTINATION libexec/darling/etc/darling)

--- a/src/setup-ld-so.sh
+++ b/src/setup-ld-so.sh
@@ -1,7 +1,12 @@
 #! /bin/bash
 
-# This runs as root,
-# with the current directory set to ${CMAKE_INSTALL_PREFIX}/libexec/darling
+WD="$1"
+if [[ -z "$WD" ]] || [[ ! -d "$WD" ]]; then
+    echo "$(basename $0): you must provide '\$INSTALL_PREFIX/libexec/darling' directory."
+    exit 1
+fi
+
+cd "$WD"
 
 for file in /etc/ld.so.conf $(find /etc/ld.so.conf.d/ -type f); do
     # Copy lines from e.g. /etc/ld.so.conf into ./etc/ld.so.conf,


### PR DESCRIPTION
Hello,

As mentioned in #261, the `$INSTALL_PREFIX/libexec/darling/etc/ld.so.conf.d` directory is empty when packaging Darling.

We shouldn't modify the _real_ filesystem directly. Files generated at build time should be put inside `build` directory instead of root directory.

I think it's better to pass working directory as argument in `setup-ld-so.sh`, this script should be run as regular user.
BTW, the [last line](https://github.com/darlinghq/darling/blob/c7a1b4a2e7fffe5d82f4af2ff06ef002ce98a2eb/src/setup-ld-so.sh#L24) remains broken. Maybe we can do that in `setupPrefix()` in `darling.c`, or something like that?
