### PR TITLE
Fix running programs directly via `darling prog`

### DIFF
--- a/src/dyld/mldr.c
+++ b/src/dyld/mldr.c
@@ -92,13 +92,18 @@ int main(int argc, char** argv, char** envp)
 	}
 
 	// sys_execve() passes the original file path appended to the mldr path in argv[0].
-	filename = (char*) __builtin_alloca(strlen(argv[0])+1);
 
 	p = strchr(argv[0], '!');
 	if (p != NULL)
+	{
+		filename = (char*) __builtin_alloca(strlen(argv[0])+1);
 		strcpy(filename, p + 1);
+	}
 	else
+	{
+		filename = (char*) __builtin_alloca(strlen(argv[1])+1);
 		strcpy(filename, argv[1]);
+	}
 
 #ifdef __i386__
 	load(filename, &entryPoint, &mh, CPU_TYPE_X86, argv); // accept i386 only


### PR DESCRIPTION
Fixed a problem like this:
```
$ darling /usr/local/libexec/darling/usr/bin/arch
Cannot open /Volumes/SystemRoot/usr/local/libexec/da���: No such file or directory
```
The memory is corrupted :)