### PR TITLE
xcselect fixes for /usr/libexec/DeveloperTools, including all xcrun shims

### DIFF
--- a/src/xcselect/CMakeLists.txt
+++ b/src/xcselect/CMakeLists.txt
@@ -16,20 +16,46 @@ target_link_libraries(xcrun system xcselect)
 add_darling_executable(xcode-select xcode-select.c)
 target_link_libraries(xcode-select system xcselect)
 
-function(add_shim name)
+install(TARGETS xcselect DESTINATION libexec/darling/usr/lib)
+install(TARGETS xcrun xcode-select DESTINATION libexec/darling/usr/bin)
+
+function(add_shim name require_xc)
 	add_darling_executable("${name}_shim" xcrun-shim.c)
 
 	set_target_properties("${name}_shim"
 		PROPERTIES
 			OUTPUT_NAME "${name}"
-			COMPILE_FLAGS "-DTOOL_NAME=\\\"${name}\\\""
+			COMPILE_FLAGS "-DTOOL_NAME=\\\"${name}\\\" -DREQUIRE_XCODE=${require_xc}"
 	)
+
 	target_link_libraries("${name}_shim" system xcselect)
 	install(TARGETS "${name}_shim" DESTINATION libexec/darling/usr/bin)
 endfunction(add_shim)
 
-add_shim(nm)
+function(add_shims require_xc) 
+	foreach(tool ${ARGN})
+		add_shim(${tool} ${require_xc})
+	endforeach()
+endfunction(add_shims)
 
-install(TARGETS xcselect DESTINATION libexec/darling/usr/lib)
-install(TARGETS xcrun xcode-select DESTINATION libexec/darling/usr/bin)
+# TODO: c++, cc, llvm-g++, llvm-gcc -- symlinks to clang
 
+add_shims(0
+	BuildStrings CpMac DeRez GetFileInfo MergePef MvMac
+	ResMerger Rez RezDet RezWack SetFile SplitForks UnRezWack
+	ar as asa bison clang clang++ cmpdylib codesign_allocate
+	cpp ctags ctf_insert dsymutil dwarfdump flex flex++ g++
+	gatherheaderdoc gcc gcov git git-cvsserver git-receive-pack
+	git-shell git-upload-archive git-upload-pack gm4 gnumake
+	gperf hdxml2manxml headerdoc2html indent install_name_tool
+	ld lex libtool lipo lldb llvm-g++ llvm-gcc lorder m4 make
+	mig mkdep nasm ndisasm nm nmedit objdump otool pagestuff
+	ranlib rebase redo_prebinding resolveLinks rpcgen segedit
+	size strings strip svn svnadmin svndumpfilter svnlook
+	svnserve svnsync svnversion swift swiftc unifdef unifdefall
+	xml2man yacc)
+
+add_shims(1
+	agvtool desdp genstrings ibtool ictool instruments
+	iprofiler opendiff sdef sdp xcodebuild xcscontrol
+	xcsdiagnose xed)

--- a/src/xcselect/xcrun-shim.c
+++ b/src/xcselect/xcrun-shim.c
@@ -20,8 +20,9 @@ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 #include <string.h>
 
-int main(int argc, const char** argv)
+int main(int argc, char** argv)
 {
-	return xcselect_invoke_xcrun(TOOL_NAME, argc - 1, &argv[1], 0);
+	return xcselect_invoke_xcrun(TOOL_NAME, argc - 1, &argv[1],
+			REQUIRE_XCODE ? XCSELECT_FLAG_REQUIRE_XCODE : 0);
 }
 

--- a/src/xcselect/xcselect.c
+++ b/src/xcselect/xcselect.c
@@ -253,23 +253,28 @@ int xcselect_invoke_xcrun(const char* tool, int argc, char* argv[], int flags)
 					dev_dir, buf, strerror(errno));
 		}
 	}
-	else if (dir_exists("/usr/libexec/DeveloperTools") && tool != NULL)
+	else 
 	{
-		char* buf = __builtin_alloca(strlen(tool) + 30);
-		strcpy(buf, "/usr/libexec/DeveloperTools/");
-		strcat(buf, tool);
+		if (dir_exists("/usr/libexec/DeveloperTools") && tool != NULL)
+		{
+			char* buf = __builtin_alloca(strlen(tool) + 30);
+			strcpy(buf, "/usr/libexec/DeveloperTools/");
+			strcat(buf, tool);
 
-		char** argv2 = (char **) __builtin_alloca((argc+1+1) * sizeof(char*));
-		argv2[0] = buf;
-		for (int i = 0; i < argc; i++)
-			argv2[i+1] = argv[i];
-		argv2[argc+1] = NULL;
+			if (access(buf, F_OK) == 0)
+			{
+				char** argv2 = (char **) __builtin_alloca((argc+1+1) * sizeof(char*));
+				argv2[0] = buf;
+				for (int i = 0; i < argc; i++)
+					argv2[i+1] = argv[i];
+				argv2[argc+1] = NULL;
 
-		execv(buf, argv2);
-		fprintf(stderr, "xcrun: failed to exec '%s': %s\n", buf, strerror(errno));
-	}
-	else
-	{
+				execv(buf, argv2);
+				fprintf(stderr, "xcrun: failed to exec '%s': %s\n", buf, strerror(errno));
+				exit(1);
+			}
+		}
+
 		fprintf(stderr, "xcrun: cannot find developer tools, set DEVELOPER_DIR if you are using a non-standard location.\n");
 	}
 

--- a/src/xcselect/xcselect.c
+++ b/src/xcselect/xcselect.c
@@ -226,7 +226,8 @@ int xcselect_invoke_xcrun(const char* tool, int argc, char* argv[], int flags)
 			}
 			else
 			{
-				fn(getprogname(), argc, argv, dev_dir);
+				fn(tool, argc, argv, dev_dir);
+				fprintf(stderr, "xcrun: xcrun_main unexpectedly exited\n");
 			}
 		}
 		else

--- a/src/xcselect/xcselect.c
+++ b/src/xcselect/xcselect.c
@@ -237,7 +237,8 @@ int xcselect_invoke_xcrun(const char* tool, int argc, char* argv[], int flags)
 			buf[length] = 0;
 			strcat(buf, "usr/bin/xcrun");
 
-			argv2 = (char**) __builtin_alloca((argc+2) * sizeof(char*));
+			// +3: buf, tool, NULL
+			argv2 = (char**) __builtin_alloca((argc+3) * sizeof(char*));
 			argv2[j++] = buf;
 
 			if (tool != NULL)
@@ -245,6 +246,7 @@ int xcselect_invoke_xcrun(const char* tool, int argc, char* argv[], int flags)
 
 			for (int i = 0; i < argc; i++, j++)
 				argv2[j] = argv[i];
+			argv2[j] = NULL;
 
 			execv(buf, argv2);
 			fprintf(stderr, "xcrun: developer path '%s' is invalid, failed to execute '%s': %s\n",
@@ -257,7 +259,13 @@ int xcselect_invoke_xcrun(const char* tool, int argc, char* argv[], int flags)
 		strcpy(buf, "/usr/libexec/DeveloperTools/");
 		strcat(buf, tool);
 
-		execv(buf, argv);
+		char** argv2 = (char **) __builtin_alloca((argc+1+1) * sizeof(char*));
+		argv2[0] = buf;
+		for (int i = 0; i < argc; i++)
+			argv2[i+1] = argv[i];
+		argv2[argc+1] = NULL;
+
+		execv(buf, argv2);
 		fprintf(stderr, "xcrun: failed to exec '%s': %s\n", buf, strerror(errno));
 	}
 	else


### PR DESCRIPTION
Add all shims (which were present on my macOS Sierra install).
Add REQUIRE_XCODE define support to xcrun-shim.c to specify flag for xcselect_invoke_xcrun

Also fix xcselect_invoke_xcrun invoking execv with invalid argv when executing from `/usr/libexec/DeveloperTools`