### PR TITLE
Fix sys_symlinkat() parameter order

### DIFF
--- a/src/kernel/emulation/linux/unistd/symlinkat.c
+++ b/src/kernel/emulation/linux/unistd/symlinkat.c
@@ -7,11 +7,11 @@
 
 extern char* strcpy(char* dst, const char* src);
 
-long sys_symlinkat(int fd, const char* path, const char* link)
+long sys_symlinkat(const char* path, int fd, const char* link)
 {
 	int ret;
 
-	ret = LINUX_SYSCALL(__NR_symlinkat, atfd(fd), path, link);
+	ret = LINUX_SYSCALL(__NR_symlinkat, path, atfd(fd), link);
 	if (ret < 0)
 		ret = errno_linux_to_bsd(ret);
 

--- a/src/kernel/emulation/linux/unistd/symlinkat.h
+++ b/src/kernel/emulation/linux/unistd/symlinkat.h
@@ -1,7 +1,7 @@
 #ifndef LINUX_SYMLINKAT_H
 #define LINUX_SYMLINKAT_H
 
-long sys_symlinkat(int fd, const char* path, const char* link);
+long sys_symlinkat(const char* path, int fd, const char* link);
 
 #endif
 


### PR DESCRIPTION
With the new sys_symlink() implementation in 09c2ed88ee9d0a4864b1ccd309fd321720b81a89 using sys_symlinkat(), this bug became easier to spot and broke all symlink creation.