### PR TITLE
Implement CNLabeledValue

### DIFF
--- a/src/Contacts/include/Contacts/CNLabeledValue.h
+++ b/src/Contacts/include/Contacts/CNLabeledValue.h
@@ -19,6 +19,20 @@
 
 #include <Foundation/Foundation.h>
 
-@interface CNLabeledValue : NSObject
+@interface CNLabeledValue<__covariant ValueType> : NSObject <NSCopying,NSSecureCoding>
+
+- (instancetype)initWithLabel:(NSString *)label value:(ValueType)value;
++ (instancetype)labeledValueWithLabel:(NSString *)label value:(ValueType)value;
+
+@property(readonly, copy, atomic) NSString *label;
+@property(readonly, copy, atomic) ValueType value;
+
+- (instancetype)labeledValueBySettingLabel:(NSString *)label;
+- (instancetype)labeledValueBySettingLabel:(NSString *)label value:(ValueType)value;
+- (instancetype)labeledValueBySettingValue:(ValueType)value;
+
++ (NSString *)localizedStringForLabel:(NSString *)label;
+
+@property(readonly, copy, atomic) NSString *identifier;
 
 @end

--- a/src/Contacts/include/Contacts/CNLabeledValue.h
+++ b/src/Contacts/include/Contacts/CNLabeledValue.h
@@ -21,18 +21,18 @@
 
 @interface CNLabeledValue<__covariant ValueType> : NSObject <NSCopying,NSSecureCoding>
 
-- (instancetype)initWithLabel:(NSString *)label value:(ValueType)value;
-+ (instancetype)labeledValueWithLabel:(NSString *)label value:(ValueType)value;
+- (nonnull instancetype)initWithLabel:(nullable NSString *)label value:(nonnull ValueType)value;
++ (nonnull instancetype)labeledValueWithLabel:(nullable NSString *)label value:(nonnull ValueType)value;
 
-@property(readonly, copy, atomic) NSString *label;
-@property(readonly, copy, atomic) ValueType value;
+@property(readonly, copy, atomic, nullable) NSString *label;
+@property(readonly, copy, atomic, nonnull) ValueType value;
 
-- (instancetype)labeledValueBySettingLabel:(NSString *)label;
-- (instancetype)labeledValueBySettingLabel:(NSString *)label value:(ValueType)value;
-- (instancetype)labeledValueBySettingValue:(ValueType)value;
+- (nonnull instancetype)labeledValueBySettingLabel:(nullable NSString *)label;
+- (nonnull instancetype)labeledValueBySettingLabel:(nullable NSString *)label value:(nonnull ValueType)value;
+- (nonnull instancetype)labeledValueBySettingValue:(nonnull ValueType)value;
 
-+ (NSString *)localizedStringForLabel:(NSString *)label;
++ (nonnull NSString *)localizedStringForLabel:(nonnull NSString *)label;
 
-@property(readonly, copy, atomic) NSString *identifier;
+@property(readonly, copy, atomic, nonnull) NSString *identifier;
 
 @end

--- a/src/Contacts/include/Contacts/CNLabeledValue.h
+++ b/src/Contacts/include/Contacts/CNLabeledValue.h
@@ -19,13 +19,17 @@
 
 #include <Foundation/Foundation.h>
 
-@interface CNLabeledValue<__covariant ValueType> : NSObject <NSCopying,NSSecureCoding>
+@interface CNLabeledValue<__covariant ValueType> : NSObject <NSCopying,NSSecureCoding> {
+	NSString *_label;
+	ValueType _value;
+	NSString *_identifier;
+}
 
 - (nonnull instancetype)initWithLabel:(nullable NSString *)label value:(nonnull ValueType)value;
 + (nonnull instancetype)labeledValueWithLabel:(nullable NSString *)label value:(nonnull ValueType)value;
 
-@property(readonly, copy, atomic, nullable) NSString *label;
-@property(readonly, copy, atomic, nonnull) ValueType value;
+@property(readonly, copy, NS_NONATOMIC_IOSONLY, nullable) NSString *label;
+@property(readonly, copy, NS_NONATOMIC_IOSONLY, nonnull) ValueType value;
 
 - (nonnull instancetype)labeledValueBySettingLabel:(nullable NSString *)label;
 - (nonnull instancetype)labeledValueBySettingLabel:(nullable NSString *)label value:(nonnull ValueType)value;
@@ -33,6 +37,6 @@
 
 + (nonnull NSString *)localizedStringForLabel:(nonnull NSString *)label;
 
-@property(readonly, copy, atomic, nonnull) NSString *identifier;
+@property(readonly, copy, NS_NONATOMIC_IOSONLY, nonnull) NSString *identifier;
 
 @end

--- a/src/Contacts/src/CNLabeledValue.m
+++ b/src/Contacts/src/CNLabeledValue.m
@@ -22,35 +22,69 @@
 @implementation CNLabeledValue
 
 - (instancetype)initWithLabel:(NSString *)label value:(id)value {
+    if (self = [super init]) {
+//        [self applyLabeledValueVariablesIdentifier: [[NSUUID alloc] init].UUIDString label:label value:value];
+        [self applyLabeledValueVariablesIdentifier: [[NSUUID alloc] init].UUIDString label:label value:value];
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier label:(NSString *)label value:(id)value {
+    if (self = [super init]) {
+        [self applyLabeledValueVariablesIdentifier:identifier label:label value:value];
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    [_identifier release];
+    [_label release];
+    [_value release];
+    [super dealloc];
+}
+
+- (instancetype)applyLabeledValueVariablesIdentifier:(NSString *)identifier label:(NSString *)label value:(id)value {
+    if (value == nil) {
+        @throw [[NSException alloc] initWithName:@"CNPropertyInvalidTypeExpression" reason:@"Variable value cannot be null." userInfo:nil];
+    }
+    
+    _identifier = [identifier copy];
+    _label = [label copy];
+    _value = [value copy];
     return self;
 }
 
 + (instancetype)labeledValueWithLabel:(NSString *)label value:(id)value {
-    id new_class = [[[self class] alloc] init];
-    return new_class;
+    return [[[[self class] alloc] initWithLabel:label value:value] autorelease];
 }
 
 - (instancetype)labeledValueBySettingLabel:(NSString *)label {
-    return self;
+    return [[[[self class] alloc] initWithIdentifier:_identifier label:label value:_value] autorelease];
 }
 
 - (instancetype)labeledValueBySettingLabel:(NSString *)label value:(id)value {
-    return self;
+    return [[[[self class] alloc] initWithIdentifier:_identifier label:label value:value] autorelease];
 }
 
 - (instancetype)labeledValueBySettingValue:(id)value {
-    return self;
+    return [[[[self class] alloc] initWithIdentifier:_identifier label:_label value:value] autorelease];
 }
 
+/*
+ TODO: Add support for obtaining localized string from contact label
+ */
 + (NSString *)localizedStringForLabel:(NSString *)label {
-    return @"";
+    // If you provide a custom label, it will return the same label.
+    return label;
 }
 
 
 // NSCopy
-- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+- (id)copyWithZone:(NSZone *)zone {
     id copy = [[[self class] alloc] init];
-    return copy;
+    return [copy autorelease];
 }
 
 
@@ -59,14 +93,13 @@
     return YES;
 }
 
-- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+- (void)encodeWithCoder:(NSCoder *)aCoder {
     return;
 }
 
-- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
     return self;
 }
-
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
     return [NSMethodSignature signatureWithObjCTypes: "v@:"];

--- a/src/Contacts/src/CNLabeledValue.m
+++ b/src/Contacts/src/CNLabeledValue.m
@@ -21,6 +21,53 @@
 
 @implementation CNLabeledValue
 
+- (instancetype)initWithLabel:(NSString *)label value:(id)value {
+    return self;
+}
+
++ (instancetype)labeledValueWithLabel:(NSString *)label value:(id)value {
+    id new_class = [[[self class] alloc] init];
+    return new_class;
+}
+
+- (instancetype)labeledValueBySettingLabel:(NSString *)label {
+    return self;
+}
+
+- (instancetype)labeledValueBySettingLabel:(NSString *)label value:(id)value {
+    return self;
+}
+
+- (instancetype)labeledValueBySettingValue:(id)value {
+    return self;
+}
+
++ (NSString *)localizedStringForLabel:(NSString *)label {
+    return @"";
+}
+
+
+// NSCopy
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    id copy = [[[self class] alloc] init];
+    return copy;
+}
+
+
+// NSSecureCoder
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+    return;
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+    return self;
+}
+
+
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
     return [NSMethodSignature signatureWithObjCTypes: "v@:"];
 }


### PR DESCRIPTION
I created stubs for the `CNLabeledValue` class. These functions are based on what the Apple developer website described. For the coding style, I went with how the website written the functions/variables. Hopefully I did not mess up here, but let me know if you want me to change anything.

With that being said, I do have a few questions/comments:

- I noticed that there is are two functions in the `CNLabeledValue.m`. I am not sure what they are used for so I left them there:

```
- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;
- (void)forwardInvocation:(NSInvocation *)anInvocation;
```

- For iOS and watchOS, the variables are `nonatomic` while MacOS is `atomic`. I recall there being a way to the let the compiler know if you want to use nonatomic or atomic, but I don't remember how to implement it (and my google skills are failing me).

- I ordered the functions and variables based on the website.