### PR TITLE
Add more basic Carbon, ApplicationServices, CoreServices stubs

### DIFF
--- a/src/ApplicationServices/ApplicationServices.c
+++ b/src/ApplicationServices/ApplicationServices.c
@@ -11,4 +11,319 @@ const CFStringRef kAXUIElementCopyHierarchyTruncateStringsKey = CFSTR("AXTRUNC")
 /* Not const for some reason */
 CFStringRef kAXTrustedCheckOptionPrompt = CFSTR("AXTrustedCheckOptionPrompt");
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CGDirectDisplay.h>
+#include <CoreGraphics/CGGeometry.h>
+#include "MacTypes.h"
+
+static int verbose = 0;
+
+__attribute__((constructor))
+static void initme(void) {
+    verbose = getenv("STUB_VERBOSE") != NULL;
+}
+
+// Types we need for the following stubs...
+
+typedef uint32_t ATSFontRef;
+typedef OptionBits ATSOptionFlags;
+typedef void* ATSUTextLayout;
+typedef void* ATSUStyle;
+typedef uint32_t ATSUAttributeTag;
+typedef Fixed ATSUTextMeasurement;
+typedef void* ATSUAttributeValuePtr;
+
+typedef float CGGammaValue;
+typedef int32_t CGWindowLevel;
+
+typedef uint32_t UniCharArrayOffset;
+typedef char* ConstUniCharArrayPtr;
+
+typedef void* ATSFontMetrics;
+typedef void** GDHandle;
+
+typedef uint32_t FMFont;
+
+
+// CGDirect Stubs - should probably be in cocoatron
+
+CGError CGDisplayShowCursor(CGDirectDisplayID display)
+{
+    if (verbose) puts("STUB: CGDisplayShowCursor called");
+	return (CGError)0;
+}
+
+boolean_t CGCursorIsVisible(void)
+{
+    if (verbose) puts("STUB: CGCursorIsVisible called");
+	return false;
+}
+
+CFArrayRef CGDisplayAvailableModes(CGDirectDisplayID a)
+{
+	// Usual keys: Width, Height, Mode, BitsPerPixel, SamplesPerPixel, RefreshRate, UsableForDesktopGUI, IOFlags, kCGDisplayBytesPerRow, IODisplayModeID
+
+    if (verbose) puts("STUB: CGDisplayAvailableModes called");
+
+    CFTypeRef arrayValues[ 1 ];
+
+    CFTypeRef dummyDisplayKeys[ 3 ];
+    CFTypeRef dummyDisplayValues[ 3 ];
+
+    dummyDisplayKeys[0] = CFSTR("Width");
+    dummyDisplayKeys[1] = CFSTR("Height");
+    dummyDisplayKeys[2] = CFSTR("BitsPerPixel");
+
+    // TODO: put some real values here
+    int val = 640;
+    dummyDisplayValues[0] = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &val);
+    val = 480;
+    dummyDisplayValues[1] = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &val);
+    val = 32;
+    dummyDisplayValues[2] = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &val);
+
+    CFDictionaryRef dictionary = CFDictionaryCreate(
+        kCFAllocatorDefault,
+        (const void **)&dummyDisplayKeys,
+        (const void **)&dummyDisplayValues,
+        3,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks
+    );
+
+    arrayValues[0] = dictionary;
+
+    CFArrayRef ret = CFArrayCreate(kCFAllocatorDefault, 
+    	                      &arrayValues, 
+    	                      1, 
+    	                      &kCFTypeArrayCallBacks);
+
+    CFRelease(dummyDisplayValues[0]);
+    CFRelease(dummyDisplayValues[1]);
+    CFRelease(dummyDisplayValues[2]);
+
+    // TODO: autorelease ret?
+	return ret;
+}
+
+CGRect CGDisplayBounds(CGDirectDisplayID a)
+{
+    if (verbose) puts("STUB: CGDisplayBounds called");
+	return CGRectMake(0,0,640,480);
+}
+
+CGError CGDisplayHideCursor(CGDirectDisplayID a)
+{
+    if (verbose) puts("STUB: CGDisplayHideCursor called");
+	return (CGError)0;
+}
+
+CGOpenGLDisplayMask CGDisplayIDToOpenGLDisplayMask(CGDirectDisplayID a)
+{
+    if (verbose) puts("STUB: CGDisplayIDToOpenGLDisplayMask called");
+	return 0;
+}
+
+CGError CGDisplayMoveCursorToPoint(CGDirectDisplayID a, CGPoint b)
+{
+    if (verbose) puts("STUB: CGDisplayMoveCursorToPoint called");
+	return (CGError)0;
+}
+
+void CGDisplayRestoreColorSyncSettings(void)
+{
+    if (verbose) puts("STUB: CGDisplayRestoreColorSyncSettings called");
+	
+}
+
+CGError CGGetActiveDisplayList(uint32_t a, CGDirectDisplayID *b, uint32_t *c)
+{
+    if (verbose) puts("STUB: CGGetActiveDisplayList called");
+	return (CGError)0;
+}
+
+CGError CGGetDisplayTransferByFormula(CGDirectDisplayID a, CGGammaValue *b, CGGammaValue *c, CGGammaValue *d, CGGammaValue *e, CGGammaValue *f, CGGammaValue *g, CGGammaValue *h, CGGammaValue *i, CGGammaValue *j)
+{
+    if (verbose) puts("STUB: CGGetDisplayTransferByFormula called");
+	return (CGError)0;
+}
+
+CGError CGGetDisplayTransferByTable(CGDirectDisplayID a, uint32_t b, CGGammaValue *c, CGGammaValue *d, CGGammaValue *e, uint32_t *f)
+{
+    if (verbose) puts("STUB: CGGetDisplayTransferByTable called");
+	return (CGError)0;
+}
+
+void CGGetLastMouseDelta(int32_t *a, int32_t *b)
+{
+    if (verbose) puts("STUB: CGGetLastMouseDelta called");
+	
+}
+
+CGDirectDisplayID CGMainDisplayID(void)
+{
+    if (verbose) puts("STUB: CGMainDisplayID called");
+	return (CGDirectDisplayID)0;
+}
+
+CGError CGSetDisplayTransferByFormula(CGDirectDisplayID a, CGGammaValue b, CGGammaValue c, CGGammaValue d, CGGammaValue e, CGGammaValue f, CGGammaValue g, CGGammaValue h, CGGammaValue i, CGGammaValue j)
+{
+    if (verbose) puts("STUB: CGSetDisplayTransferByFormula called");
+	return (CGError)0;
+}
+
+CGError CGSetDisplayTransferByTable(CGDirectDisplayID a, uint32_t b, const CGGammaValue *c, const CGGammaValue *d, const CGGammaValue *e)
+{
+    if (verbose) puts("STUB: CGSetDisplayTransferByTable called");
+	return (CGError)0;
+}
+
+CGError CGSetLocalEventsSuppressionInterval(CFTimeInterval a)
+{
+    if (verbose) puts("STUB: CGSetLocalEventsSuppressionInterval called");
+	return (CGError)0;
+}
+
+CGWindowLevel CGShieldingWindowLevel(void)
+{
+    if (verbose) puts("STUB: CGShieldingWindowLevel called");
+	return 0;
+}
+
+// End CGDirect Stubs
+
+
+// ATS Stubs
+
+ATSFontRef ATSFontFindFromName(CFStringRef a, ATSOptionFlags b)
+{
+    if (verbose) puts("STUB: ATSFontFindFromName called");
+	return 0;
+}
+
+OSStatus ATSFontGetHorizontalMetrics(ATSFontRef a, ATSOptionFlags b, ATSFontMetrics *c)
+{
+    if (verbose) puts("STUB: ATSFontGetHorizontalMetrics called");
+	return 0;
+}
+
+OSStatus ATSUCreateStyle(ATSUStyle *a)
+{
+    if (verbose) puts("STUB: ATSUCreateStyle called");
+	return 0;
+}
+
+OSStatus ATSUCreateTextLayout(ATSUTextLayout *a)
+{
+    if (verbose) puts("STUB: ATSUCreateTextLayout called");
+	return 0;
+}
+
+OSStatus ATSUDisposeStyle(ATSUStyle *a)
+{
+    if (verbose) puts("STUB: ATSUDisposeStyle called");
+	return 0;
+}
+
+OSStatus ATSUDisposeTextLayout(ATSUTextLayout *a)
+{
+    if (verbose) puts("STUB: ATSUDisposeTextLayout called");
+	return 0;
+}
+
+OSStatus ATSUDrawText(ATSUTextLayout a, UniCharArrayOffset b, UniCharCount c, ATSUTextMeasurement d, ATSUTextMeasurement e)
+{
+    if (verbose) puts("STUB: ATSUDrawText called");
+	return 0;
+}
+
+OSStatus ATSUGetUnjustifiedBounds(ATSUTextLayout a , UniCharArrayOffset b , UniCharCount c , ATSUTextMeasurement * d , ATSUTextMeasurement * e , ATSUTextMeasurement * f , ATSUTextMeasurement * g)
+{
+    if (verbose) puts("STUB: ATSUGetUnjustifiedBounds called");
+	return 0;
+}
+
+OSStatus ATSUMeasureTextImage(ATSUTextLayout a, UniCharArrayOffset b, UniCharCount c, ATSUTextMeasurement d, ATSUTextMeasurement e, Rect *f)
+{
+    if (verbose) puts("STUB: ATSUMeasureTextImage called");
+	return 0;
+}
+
+OSStatus ATSUSetAttributes(ATSUStyle a, ItemCount b, const ATSUAttributeTag *c, const ByteCount *d, const ATSUAttributeValuePtr *e)
+{
+    if (verbose) puts("STUB: ATSUSetAttributes called");
+	return 0;
+}
+
+OSStatus ATSUSetLayoutControls(ATSUTextLayout a, ItemCount b, const ATSUAttributeTag *c, const ByteCount *d, const ATSUAttributeValuePtr *e)
+{
+    if (verbose) puts("STUB: ATSUSetLayoutControls called");
+	return 0;
+}
+
+OSStatus ATSUSetRunStyle(ATSUTextLayout a, ATSUStyle b, UniCharArrayOffset c, UniCharCount d)
+{
+    if (verbose) puts("STUB: ATSUSetRunStyle called");
+	return 0;
+}
+
+OSStatus ATSUSetTextPointerLocation(ATSUTextLayout a, ConstUniCharArrayPtr b, UniCharArrayOffset c, UniCharCount d, UniCharCount e)
+{
+    if (verbose) puts("STUB: ATSUSetTextPointerLocation called");
+	return 0;
+}
+
+OSStatus ATSUSetTransientFontMatching(ATSUTextLayout a, Boolean b)
+{
+    if (verbose) puts("STUB: ATSUSetTransientFontMatching called");
+	return 0;
+}
+
+// End ATS Stubs
+
+// QuickDraw Stubs
+
+void InitCursor()
+{
+    if (verbose) puts("STUB: InitCursor called");	
+}
+
+static uint32_t gFakeScreenDevice;
+
+GDHandle DMGetFirstScreenDevice(Boolean a)
+{
+    if (verbose) puts("STUB: DMGetFirstScreenDevice called");
+	return (GDHandle)&gFakeScreenDevice;
+}
+
+GDHandle DMGetNextScreenDevice (GDHandle a, Boolean b)
+{
+    if (verbose) puts("STUB: DMGetNextScreenDevice called");
+	return (GDHandle)0;
+}
+
+GDHandle GetMainDevice()
+{
+    if (verbose) puts("STUB: GetMainDevice called");
+	return (GDHandle)0;
+}
+
+CGDirectDisplayID QDGetCGDirectDisplayID(GDHandle a)
+{
+    if (verbose) puts("STUB: QDGetCGDirectDisplayID called");
+	return (CGDirectDisplayID)a;
+}
+
+// End QuickDraw Stubs
+
+
+// Old QuickDraw Font Stubs
+
+FMFont FMGetFontFromATSFontRef(ATSFontRef a)
+{
+    if (verbose) puts("STUB: FMGetFontFromATSFontRef called");
+	return (FMFont)0;
+}
+
+// End Old QuickDraw Font Stubs
 

--- a/src/Carbon/CMakeLists.txt
+++ b/src/Carbon/CMakeLists.txt
@@ -10,7 +10,8 @@ add_framework(Carbon
 
     SOURCES
         src/Carbon.c
-	src/constants.c
+        src/constants.c
+        HIToolbox/MacWindows.cpp
 
     DEPENDENCIES
     	CoreFoundation

--- a/src/Carbon/HIToolbox/MacWindows.cpp
+++ b/src/Carbon/HIToolbox/MacWindows.cpp
@@ -1,13 +1,31 @@
 #include "MacWindows.h"
 #include <X11/Xlib.h>
-#include <iostream>
-#include <cstdlib>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define NO_X11 
+
+
+static int verbose = 0;
+
+__attribute__((constructor))
+static void initme(void) {
+    verbose = getenv("STUB_VERBOSE") != NULL;
+}
+
 
 static Display* g_display = nullptr;
 static void closeDisplay() __attribute__((destructor));
 
-Display* Darling::Carbon::getDisplay()
+namespace Darling
 {
+
+namespace Carbon
+{
+
+Display* getDisplay()
+{
+#ifndef NO_X11
 	if (g_display)
 		return g_display;
 
@@ -15,26 +33,33 @@ Display* Darling::Carbon::getDisplay()
 
 	if (!g_display)
 	{
-		std::cerr << "Darling Carbon: Cannot open a connection to the X server!\n";
+		fprintf(stderr, "Darling Carbon: Cannot open a connection to the X server!\n");
 		if (!getenv("DISPLAY"))
-			std::cerr << "The application you are trying to run requires an X server and cannot be run only in the console.\n";
+			fprintf(stderr, "The application you are trying to run requires an X server and cannot be run only in the console.\n");
 		abort();
 	}
 
+#endif
 	return g_display;
 }
 
 void closeDisplay()
 {
+#ifndef NO_X11
 	if (g_display)
 	{
 		XCloseDisplay(g_display);
 		g_display = nullptr;
 	}
+#endif
+}
+
+}
 }
 
 OSStatus CreateNewWindow(WindowClass cls, WindowAttributes attr, const Rect* rect, WindowRef* newWindow)
 {
+#ifndef NO_X11
 	Window win;
 	Display* dpy;
 	int blackColor, whiteColor;
@@ -56,25 +81,32 @@ OSStatus CreateNewWindow(WindowClass cls, WindowAttributes attr, const Rect* rec
 		return paramErr;
 
 	*newWindow = win;
+#endif
 	return noErr;
 }
 
 void DisposeWindow(WindowRef wnd)
 {
+#ifndef NO_X11
 	if (wnd)
-		XDestroyWindow(wnd);
+		XDestroyWindow(Darling::Carbon::getDisplay(), wnd);
+#endif
 }
 
 void ShowWindow(WindowRef wnd)
 {
+#ifndef NO_X11
 	if (wnd)
 		XMapWindow(Darling::Carbon::getDisplay(), Window(wnd));
+#endif
 }
 
 void HideWindow(WindowRef wnd)
 {
+#ifndef NO_X11
 	if (wnd)
 		XUnmapWindow(Darling::Carbon::getDisplay(), Window(wnd));
+#endif
 }
 
 void ShowHide(WindowRef wnd, Boolean showFlag)
@@ -87,6 +119,81 @@ void ShowHide(WindowRef wnd, Boolean showFlag)
 
 Boolean IsWindowVisible(WindowRef wnd)
 {
-	
+	return 0;
 }
 
+
+OSStatus SelectWindow(WindowRef a)
+{
+	return 0;
+}
+
+OSStatus SetWindowContentColor(WindowRef a, const RGBColor * b)
+{
+	return 0;
+}
+
+OSStatus SetWindowGroup(WindowRef a, WindowGroupRef b)
+{
+	return 0;
+}
+
+OSStatus SetWindowGroupLevel(WindowGroupRef a, SInt32 b)
+{
+	return 0;
+}
+
+OSStatus SetWindowTitleWithCFString(WindowRef a, CFStringRef b)
+{
+	return 0;
+}
+
+OSStatus TransitionWindowWithOptions(WindowRef a, WindowTransitionEffect b, WindowTransitionAction c, const HIRect * d, Boolean e, TransitionWindowOptions * f)
+{
+	return 0;
+}
+
+OSStatus CreateWindowGroup(WindowGroupAttributes a, WindowGroupRef *b)
+{
+	return 0;
+}
+
+OSStatus GetWindowBounds(WindowRef a, WindowRegionCode b, Rect * c)
+{
+	return 0;
+}
+
+OSStatus GetWindowEventTarget(WindowRef a)
+{
+	return 0;
+}
+
+OSStatus GetWindowGroupLevel(WindowGroupRef a, SInt32 * b)
+{
+	return 0;
+}
+
+WindowGroupRef GetWindowGroupOfClass(WindowClass a)
+{
+	return (WindowGroupRef)0;
+}
+
+CGrafPtr GetWindowPort(WindowRef a)
+{
+	return (CGrafPtr)0;
+}
+
+Rect* GetWindowPortBounds(WindowRef window, Rect * bounds)
+{
+	return NULL;
+}
+
+Boolean IsValidWindowPtr(WindowRef a)
+{
+	return 0;
+}
+
+OSStatus ReleaseWindow(WindowRef a)
+{
+	return 0;
+}

--- a/src/Carbon/HIToolbox/MacWindows.h
+++ b/src/Carbon/HIToolbox/MacWindows.h
@@ -1,24 +1,35 @@
 #ifndef MACWINDOWS_H
 #define MACWINDOWS_H
-//#include <X11/Xlib.h>
-#include "../../CoreServices/MacErrors.h"
-#include "../../CoreServices/MacTypes.h"
+
+#include <X11/Xlib.h>
+#include "CoreServices/MacErrors.h"
+#include "CoreServices/MacTypes.h"
 #include <stdint.h>
 
 #pragma pack(2)
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 typedef int WindowRef; // mapped to X11 Window
 typedef WindowRef HIWindowRef;
+typedef int WindowGroupRef;
+typedef void* CGrafPtr;
 
 typedef uint32_t WindowClass;
 typedef OptionBits WindowAttributes;
+typedef OptionBits WindowGroupAttributes;
+typedef uint32_t WindowRegionCode;
 
-struct Rect
-{
-	short top, left, bottom, right;
-};
+typedef Rect HIRect;
+typedef void* TransitionWindowOptions;
+typedef uint32_t WindowTransitionAction;
+typedef uint32_t WindowTransitionEffect;
+
+typedef struct RGBColor {
+	uint16_t components[3];
+} RGBColor;
 
 OSStatus CreateNewWindow(WindowClass cls, WindowAttributes attr, const Rect* rect, WindowRef* newWindow);
 void DisposeWindow(WindowRef wnd);
@@ -28,14 +39,27 @@ void HideWindow(WindowRef wnd);
 void ShowHide(WindowRef wnd, Boolean showFlag);
 Boolean IsWindowVisible(WindowRef wnd);
 
+
+OSStatus SelectWindow(WindowRef a);
+OSStatus SetWindowContentColor(WindowRef a, const RGBColor * b);
+OSStatus SetWindowGroup(WindowRef a, WindowGroupRef b);
+OSStatus SetWindowGroupLevel(WindowGroupRef a, SInt32 b);
+OSStatus SetWindowTitleWithCFString(WindowRef a, CFStringRef b);
+OSStatus TransitionWindowWithOptions(WindowRef a, WindowTransitionEffect b, WindowTransitionAction c, const HIRect * d, Boolean e, TransitionWindowOptions * f);
+OSStatus CreateWindowGroup(WindowGroupAttributes a, WindowGroupRef *b);
+OSStatus GetWindowBounds(WindowRef a, WindowRegionCode b, Rect * c);
+OSStatus GetWindowEventTarget(WindowRef a);
+OSStatus GetWindowGroupLevel(WindowGroupRef a, SInt32 * b);
+WindowGroupRef GetWindowGroupOfClass(WindowClass a);
+CGrafPtr GetWindowPort(WindowRef a);
+Rect* GetWindowPortBounds(WindowRef window, Rect * bounds);
+Boolean IsValidWindowPtr(WindowRef a);
+OSStatus ReleaseWindow(WindowRef a);
+
+
+#ifdef __cplusplus
 }
-
-namespace Darling {
-namespace Carbon {
-
-Display* getDisplay();
-
-}} // end namespaces
+#endif
 
 #pragma pack()
 

--- a/src/Carbon/include/Carbon/Carbon.h
+++ b/src/Carbon/include/Carbon/Carbon.h
@@ -21,5 +21,16 @@
 #ifndef _Carbon_H_
 #define _Carbon_H_
 
+#include "CoreServices/MacErrors.h"
+#include "CoreServices/MacTypes.h"
+
+#include <HIToolbox/CarbonEventsCore.h>
+#include <HIToolbox/CarbonEvents.h>
+#include <HIToolbox/Dialogs.h>
+#include <HIToolbox/Events.h>
+#include <HIToolbox/Menus.h>
+#include <HIToolbox/Notification.h>
+#include <HIToolbox/Scrap.h>
+#include <HIToolbox/TextServices.h>
 
 #endif

--- a/src/Carbon/include/HIToolbox/CarbonEvents.h
+++ b/src/Carbon/include/HIToolbox/CarbonEvents.h
@@ -1,0 +1,20 @@
+#ifndef _Carbon_Carbon_Events_H_
+#define _Carbon_Carbon_Events_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+EventTargetRef GetApplicationEventTarget(void);
+OSStatus GetEventDispatcherTarget();
+
+OSStatus ProcessHICommand(const HICommand * a);
+
+void RunApplicationEventLoop(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/CarbonEventsCore.h
+++ b/src/Carbon/include/HIToolbox/CarbonEventsCore.h
@@ -1,0 +1,54 @@
+#ifndef _Carbon_Carbon_Events_Core_H_
+#define _Carbon_Carbon_Events_Core_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int EventRef;
+typedef void* EventHandlerCallRef;
+typedef OSType EventParamType;
+
+typedef double EventTime;
+typedef uint32_t EventMask;
+typedef void* EventTargetRef;
+typedef OSType EventParamName;
+typedef struct EventTypeSpec { uint32_t params[2]; } EventTypeSpec;
+typedef EventTime EventTimeout;
+typedef void* EventHandlerProcPtr;
+typedef uint32_t EventAttributes;
+typedef uint32_t EventQueueRef;
+typedef void* EventHandlerUPP;
+typedef int16_t EventPriority;
+typedef void* EventHandlerRef;
+
+
+typedef struct HICommand { uint8_t data[16]; } HICommand;
+typedef struct KeyMap { char data[16]; } KeyMap;
+
+
+OSStatus CallNextEventHandler(EventHandlerCallRef a, EventRef b);
+OSStatus CreateEvent(CFAllocatorRef a, UInt32 b, UInt32 c, EventTime d, EventAttributes e, EventRef * f);
+UInt32 GetEventClass(EventRef a);
+UInt32 GetEventKind(EventRef a);
+OSStatus GetEventParameter(EventRef a, EventParamName b, EventParamType c, EventParamType * d, UInt32 e, UInt32 * f, void * g);
+
+OSStatus GetMainEventQueue();
+OSStatus InstallEventHandler(EventTargetRef a, EventHandlerUPP b, UInt32 c, const EventTypeSpec * d, void * e, EventHandlerRef * f);
+
+
+EventHandlerUPP NewEventHandlerUPP(EventHandlerProcPtr a); 
+OSStatus PostEventToQueue(EventQueueRef a, EventRef b, EventPriority c);
+
+OSStatus ReceiveNextEvent(UInt32 a, const EventTypeSpec * b, EventTimeout c, Boolean d, EventRef * e);
+
+OSStatus ReleaseEvent(EventRef a);
+OSStatus RemoveEventHandler(EventHandlerRef a);
+
+OSStatus SendEventToEventTarget(EventRef a, EventTargetRef b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/Dialogs.h
+++ b/src/Carbon/include/HIToolbox/Dialogs.h
@@ -1,0 +1,26 @@
+#ifndef _Carbon_Dialogs_H_
+#define _Carbon_Dialogs_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int16_t AlertType;
+typedef void* DialogRef;
+typedef uint32_t AlertStdCFStringAlertParamRec;
+typedef void* AlertStdCFStringAlertParamPtr;
+
+typedef int16_t DialogItemIndex;
+typedef void* ModalFilterUPP;
+
+OSStatus CreateStandardAlert(AlertType a, CFStringRef b, CFStringRef c, const AlertStdCFStringAlertParamRec * d, DialogRef * e);
+OSStatus GetStandardAlertDefaultParams(AlertStdCFStringAlertParamPtr a, UInt32 b);
+
+OSStatus RunStandardAlert(DialogRef a, ModalFilterUPP b, DialogItemIndex * c);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/Events.h
+++ b/src/Carbon/include/HIToolbox/Events.h
@@ -1,0 +1,18 @@
+#ifndef _Carbon_Events_H_
+#define _Carbon_Events_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GetKeys(KeyMap theKeys);
+void FlushEvents(EventMask a, EventMask b);
+
+OSStatus SetEventMask(EventMask a);
+OSStatus SetEventParameter(EventRef a, EventParamName b, EventParamType c, UInt32 d, const void * e);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/Menus.h
+++ b/src/Carbon/include/HIToolbox/Menus.h
@@ -1,0 +1,15 @@
+#ifndef _Carbon_Menus_H_
+#define _Carbon_Menus_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ShowMenuBar(void);
+void HideMenuBar(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/Notification.h
+++ b/src/Carbon/include/HIToolbox/Notification.h
@@ -1,0 +1,17 @@
+#ifndef _Carbon_Notification_H_
+#define _Carbon_Notification_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* NMRecPtr;
+
+OSErr NMInstall(NMRecPtr a);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/Scrap.h
+++ b/src/Carbon/include/HIToolbox/Scrap.h
@@ -1,0 +1,24 @@
+#ifndef _Carbon_Scrap_H_
+#define _Carbon_Scrap_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* ScrapRef;
+typedef uint32_t ScrapFlavorType;
+typedef uint32_t ScrapFlavorFlags;
+typedef uint32_t ScrapFlavorType;
+
+OSStatus PutScrapFlavor(ScrapRef a, ScrapFlavorType b, ScrapFlavorFlags c, Size d, const void * e);
+
+OSStatus GetScrapByName(CFStringRef a, OptionBits b, ScrapRef * c);
+OSStatus GetScrapFlavorData(ScrapRef a, ScrapFlavorType b, Size * c, void * d);
+OSStatus GetScrapFlavorSize(ScrapRef a, ScrapFlavorType b, Size * c);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/include/HIToolbox/TextServices.h
+++ b/src/Carbon/include/HIToolbox/TextServices.h
@@ -1,0 +1,22 @@
+#ifndef _Carbon_TextServices_H_
+#define _Carbon_TextServices_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t TSMDocumentID;
+typedef OSType InterfaceTypeList[1];
+
+OSErr ActivateTSMDocument(TSMDocumentID a);
+OSErr DeactivateTSMDocument(TSMDocumentID a);
+OSErr NewTSMDocument(short a, InterfaceTypeList b, TSMDocumentID * c, long d);
+
+
+OSErr UseInputWindow(TSMDocumentID a, Boolean b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Carbon/src/Carbon.c
+++ b/src/Carbon/src/Carbon.c
@@ -19,6 +19,7 @@
 
 
 #include <Carbon/Carbon.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -28,3 +29,215 @@ __attribute__((constructor))
 static void initme(void) {
     verbose = getenv("STUB_VERBOSE") != NULL;
 }
+
+
+// These stubs should prob be moved elsewhere
+
+OSErr ActivateTSMDocument(TSMDocumentID a)
+{
+    if (verbose) puts("STUB: ActivateTSMDocument called");
+	return 0;
+}
+
+OSErr DeactivateTSMDocument(TSMDocumentID a)
+{
+    if (verbose) puts("STUB: DeactivateTSMDocument called");
+	return 0;
+}
+
+OSStatus CallNextEventHandler(EventHandlerCallRef a, EventRef b)
+{
+    if (verbose) puts("STUB: CallNextEventHandler called");
+	return 0;
+}
+
+OSStatus CreateEvent(CFAllocatorRef a, UInt32 b, UInt32 c, EventTime d, EventAttributes e, EventRef * f)
+{
+    if (verbose) puts("STUB: CreateEvent called");
+	return 0;
+}
+
+OSStatus CreateStandardAlert(AlertType a, CFStringRef b, CFStringRef c, const AlertStdCFStringAlertParamRec * d, DialogRef * e)
+{
+    if (verbose) puts("STUB: CreateStandardAlert called");
+	return 0;
+}
+
+OSErr UseInputWindow(TSMDocumentID a, Boolean b)
+{
+    if (verbose) puts("STUB: UseInputWindow called");
+	return 0;
+}
+
+void FlushEvents(EventMask a, EventMask b)
+{
+    if (verbose) puts("STUB: FlushEvents called");
+}
+
+EventTargetRef GetApplicationEventTarget(void)
+{
+    if (verbose) puts("STUB: GetApplicationEventTarget called");
+	return (EventTargetRef)0;
+}
+
+UInt32 GetEventClass(EventRef a)
+{
+    if (verbose) puts("STUB: GetEventClass called");
+	return 0;
+}
+
+OSStatus GetEventDispatcherTarget()
+{
+    if (verbose) puts("STUB: GetEventDispatcherTarget called");
+	return 0;
+}
+
+UInt32 GetEventKind(EventRef a)
+{
+    if (verbose) puts("STUB: GetEventKind called");
+	return 0;
+}
+
+OSStatus GetEventParameter(EventRef a, EventParamName b, EventParamType c, EventParamType * d, UInt32 e, UInt32 * f, void * g)
+{
+    if (verbose) puts("STUB: GetEventParameter called");
+	return 0;
+}
+
+OSStatus GetMainEventQueue()
+{
+    if (verbose) puts("STUB: GetMainEventQueue called");
+	return 0;
+}
+
+OSStatus GetScrapByName(CFStringRef a, OptionBits b, ScrapRef * c)
+{
+    if (verbose) puts("STUB: GetScrapByName called");
+	return 0;
+}
+
+OSStatus GetScrapFlavorData(ScrapRef a, ScrapFlavorType b, Size * c, void * d)
+{
+    if (verbose) puts("STUB: GetScrapFlavorData called");
+	return 0;
+}
+
+OSStatus GetScrapFlavorSize(ScrapRef a, ScrapFlavorType b, Size * c)
+{
+    if (verbose) puts("STUB: GetScrapFlavorSize called");
+	return 0;
+}
+
+OSStatus GetStandardAlertDefaultParams(AlertStdCFStringAlertParamPtr a, UInt32 b)
+{
+    if (verbose) puts("STUB: GetStandardAlertDefaultParams called");
+	return 0;
+}
+
+void HideMenuBar(void)
+{
+    if (verbose) puts("STUB: HideMenuBar called");
+	
+}
+
+OSStatus InstallEventHandler(EventTargetRef a, EventHandlerUPP b, UInt32 c, const EventTypeSpec * d, void * e, EventHandlerRef * f)
+{
+    if (verbose) puts("STUB: InstallEventHandler called");
+	return 0;
+}
+
+OSErr NMInstall(NMRecPtr a)
+{
+    if (verbose) puts("STUB: NMInstall called");
+	return 0;
+}
+
+EventHandlerUPP NewEventHandlerUPP(EventHandlerProcPtr a)
+{
+    if (verbose) puts("STUB: NewEventHandlerUPP called");
+	return (EventHandlerUPP)0;
+}
+
+OSErr NewTSMDocument(short a, InterfaceTypeList b, TSMDocumentID * c, long d)
+{
+    if (verbose) puts("STUB: NewTSMDocument called");
+	return 0;
+}
+
+OSStatus PostEventToQueue(EventQueueRef a, EventRef b, EventPriority c)
+{
+    if (verbose) puts("STUB: PostEventToQueue called");
+	return 0;
+}
+
+OSStatus ProcessHICommand(const HICommand * a)
+{
+    if (verbose) puts("STUB: ProcessHICommand called");
+	return 0;
+}
+
+OSStatus PutScrapFlavor(ScrapRef a, ScrapFlavorType b, ScrapFlavorFlags c, Size d, const void * e)
+{
+    if (verbose) puts("STUB: PutScrapFlavor called");
+	return 0;
+}
+
+OSStatus ReceiveNextEvent(UInt32 a, const EventTypeSpec * b, EventTimeout c, Boolean d, EventRef * e)
+{
+    if (verbose) puts("STUB: ReceiveNextEvent called");
+	return 0;
+}
+
+OSStatus ReleaseEvent(EventRef a)
+{
+    if (verbose) puts("STUB: ReleaseEvent called");
+	return 0;
+}
+
+OSStatus RemoveEventHandler(EventHandlerRef a)
+{
+    if (verbose) puts("STUB: RemoveEventHandler called");
+	return 0;
+}
+
+void RunApplicationEventLoop(void)
+{
+    if (verbose) puts("STUB: RunApplicationEventLoop called");
+	
+}
+
+OSStatus RunStandardAlert(DialogRef a, ModalFilterUPP b, DialogItemIndex * c)
+{
+    if (verbose) puts("STUB: RunStandardAlert called");
+	return 0;
+}
+
+OSStatus SendEventToEventTarget(EventRef a, EventTargetRef b)
+{
+    if (verbose) puts("STUB: SendEventToEventTarget called");
+	return 0;
+}
+
+OSStatus SetEventMask(EventMask a)
+{
+    if (verbose) puts("STUB: SetEventMask called");
+	return 0;
+}
+
+OSStatus SetEventParameter(EventRef a, EventParamName b, EventParamType c, UInt32 d, const void * e)
+{
+    if (verbose) puts("STUB: SetEventParameter called");
+	return 0;
+}
+
+void ShowMenuBar(void)
+{
+    if (verbose) puts("STUB: ShowMenuBar called");
+}
+
+
+void GetKeys (KeyMap theKeys)
+{
+
+}
+

--- a/src/CoreServices/Processes.cpp
+++ b/src/CoreServices/Processes.cpp
@@ -222,4 +222,10 @@ OSErr WakeUpProcess(const ProcessSerialNumber* psn)
 	return noErr;
 }
 
+void DebugStr(ConstStr255Param a)
+{
+	printf("%s\n", a);
+}
+
+
 


### PR DESCRIPTION
Adds more function stubs with correctly sized parameters to at least get torque-based games loading, satisfying #504 . Note that while this allows them to load, they currently do not function correctly due to #514 , threading issues, and (if one ever wanted to properly play them) there is no carbon ui or gl implemented.

Function prototypes have been added to relevant headers in carbon, though for now all the actual stubs are in Carbon.c and the existing MacWindows.cpp which has now also been added to the Carbon framework build.
