### PR TITLE
32bit Syscall fix

### DIFF
--- a/src/kernel/emulation/linux/mach/darling_mach_syscall.S
+++ b/src/kernel/emulation/linux/mach/darling_mach_syscall.S
@@ -43,7 +43,7 @@ __darling_mach_syscall_exit:
 
 #define copy_arg(off) \
 	movl	8+off(%esp), %ecx ;\
-	movl	%ecx, -32+off(%esp)
+	movl	%ecx, -48+off(%esp)
 
 __darling_mach_syscall:
 	cmpl	$0, %eax
@@ -70,9 +70,14 @@ Lentry_hook:
 	copy_arg(20)
 	copy_arg(24)
 	copy_arg(28)
-	subl	$32, %esp
+	copy_arg(32)
+	copy_arg(36)
+	copy_arg(40)
+	copy_arg(44)
+
+	subl	$48, %esp
 	call	*%eax
-	addl	$32, %esp
+	addl	$48, %esp
 .std_ret:
 Lexit_hook:
 	.space 6, 0x90

--- a/src/kernel/emulation/linux/mach/darling_mach_syscall.S
+++ b/src/kernel/emulation/linux/mach/darling_mach_syscall.S
@@ -43,7 +43,7 @@ __darling_mach_syscall_exit:
 
 #define copy_arg(off) \
 	movl	8+off(%esp), %ecx ;\
-	movl	%ecx, -48+off(%esp)
+	movl	%ecx, -56+off(%esp)
 
 __darling_mach_syscall:
 	cmpl	$0, %eax
@@ -74,10 +74,12 @@ Lentry_hook:
 	copy_arg(36)
 	copy_arg(40)
 	copy_arg(44)
+	copy_arg(48)
+	copy_arg(52)
 
-	subl	$48, %esp
+	subl	$56, %esp
 	call	*%eax
-	addl	$48, %esp
+	addl	$56, %esp
 .std_ret:
 Lexit_hook:
 	.space 6, 0x90

--- a/src/kernel/emulation/linux/psynch/psynch_cvwait.c
+++ b/src/kernel/emulation/linux/psynch/psynch_cvwait.c
@@ -6,18 +6,19 @@
 #include "../../../../lkm/api.h"
 #include "../simple.h"
 
-long sys_psynch_cvwait(void* cv, uint32_t cvgen, uint32_t cvugen, void* mutex, uint64_t mgen,
-		uint32_t ugen, uint64_t sec, uint32_t usec)
+
+long sys_psynch_cvwait(void* cv, uint64_t cvlsgen, uint32_t cvugen, void * mutex, uint64_t mugen, 
+		uint32_t flags, int64_t sec, uint32_t nsec)
 {
 	struct psynch_cvwait_args args = {
 		.cv = cv,
-		.cvlsgen = cvgen,
+		.cvlsgen = cvlsgen,
 		.cvugen = cvugen,
 		.mutex = mutex,
-		.mugen = mgen,
-		.flags = ugen,
+		.mugen = mugen,
+		.flags = flags,
 		.sec = sec,
-		.nsec = usec,
+		.nsec = nsec,
 	};
 
 	// __simple_printf("sys_psynch_mutexwait(mutex=%p, mgen=%x)\n", mutex, mgen);

--- a/src/kernel/emulation/linux/psynch/psynch_cvwait.h
+++ b/src/kernel/emulation/linux/psynch/psynch_cvwait.h
@@ -2,8 +2,7 @@
 #define LINUX_PSYNCH_CVWAIT_H
 #include <stdint.h>
 
-long sys_psynch_cvwait(void* cv, uint32_t cvgen, uint32_t cvugen, void* mutex, uint64_t mgen,
-		uint32_t ugen, uint64_t sec, uint32_t usec);
+long sys_psynch_cvwait(void* cv, uint64_t cvlsgen, uint32_t cvugen, void * mutex,  uint64_t mugen, uint32_t flags, int64_t sec, uint32_t nsec);
 
 #endif
 

--- a/src/kernel/emulation/linux/syscalls-table.S
+++ b/src/kernel/emulation/linux/syscalls-table.S
@@ -39,7 +39,7 @@ __darling_bsd_syscall_exit:
 
 #define copy_arg(off) \
 	movl	8+off(%esp), %ecx ;\
-	movl	%ecx, -48+off(%esp)
+	movl	%ecx, -56+off(%esp)
 
 __darling_bsd_syscall:
 Lentry_hook:
@@ -66,9 +66,11 @@ Lentry_hook:
 	copy_arg(36)
 	copy_arg(40)
 	copy_arg(44)
-	subl	$48, %esp
+	copy_arg(48)
+	copy_arg(52)
+	subl	$56, %esp
 	call	*%eax
-	addl	$48, %esp
+	addl	$56, %esp
 .std_ret:
 Lexit_hook:
 	.space 6, 0x90

--- a/src/kernel/emulation/linux/syscalls-table.S
+++ b/src/kernel/emulation/linux/syscalls-table.S
@@ -39,7 +39,7 @@ __darling_bsd_syscall_exit:
 
 #define copy_arg(off) \
 	movl	8+off(%esp), %ecx ;\
-	movl	%ecx, -24+off(%esp)
+	movl	%ecx, -48+off(%esp)
 
 __darling_bsd_syscall:
 Lentry_hook:
@@ -60,9 +60,15 @@ Lentry_hook:
 	copy_arg(12)
 	copy_arg(16)
 	copy_arg(20)
-	subl	$24, %esp
+	copy_arg(24)
+	copy_arg(28)
+	copy_arg(32)
+	copy_arg(36)
+	copy_arg(40)
+	copy_arg(44)
+	subl	$48, %esp
 	call	*%eax
-	addl	$24, %esp
+	addl	$48, %esp
 .std_ret:
 Lexit_hook:
 	.space 6, 0x90


### PR DESCRIPTION
Fixes an issue where not all syscall parameters were copied to the thunk functions for 32bit processes, causing parameters to be in an uninitialized state for large syscalls. This affected both `__darling_mach_syscall` and `__darling_bsd_syscall`.

Partially fixes #524
