### PR TITLE
Fix typos; add kABDatabaseChangedNotification

### DIFF
--- a/src/AddressBook/include/AddressBook/ABGlobals.h
+++ b/src/AddressBook/include/AddressBook/ABGlobals.h
@@ -19,6 +19,7 @@
 
 #include <Foundation/Foundation.h>
 
+extern NSString *const kABDatabaseChangedNotification;
 extern NSString *const kABDatabaseChangedExternallyNotification;
 
 extern NSString *const kABEmailProperty;

--- a/src/AddressBook/src/ABGlobals.m
+++ b/src/AddressBook/src/ABGlobals.m
@@ -19,7 +19,8 @@
 
 #import <AddressBook/ABGlobals.h>
 
-NSString *const kABDaabaseChangedExternallyNotification=@"ABDatabaseChangedExternallyNotification";
+NSString *const kABDatabaseChangedNotification=@"ABDatabaseChangedNotification";
+NSString *const kABDatabaseChangedExternallyNotification=@"ABDatabaseChangedExternallyNotification";
 
 NSString *const kABEmailProperty=@"ABEmailProperty";
 NSString *const kABFirstNameProperty=@"ABFirstNameProperty";

--- a/src/AddressBook/src/ABRecord.m
+++ b/src/AddressBook/src/ABRecord.m
@@ -21,8 +21,6 @@
 
 @implementation ABRecord
 
-@implementation ABAddressBook
-
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
 {
     return [NSMethodSignature signatureWithObjCTypes: "v@:"];

--- a/src/Carbon/include/HIToolbox/TextInputSources.h
+++ b/src/Carbon/include/HIToolbox/TextInputSources.h
@@ -1,7 +1,7 @@
 #ifndef _Carbon_TextInputSources_H_
 #define _Carbon_TextInputSources_H_
 
-#ifndef __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -12,7 +12,7 @@ extern const CFStringRef kTISPropertyInputSourceCategory;
 extern const CFStringRef kTISPropertyInputSourceType;
 extern const CFStringRef kTISTypeKeyboardLayout;
 
-#ifndef __cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
Sorry for previous typos, I've fixed them. And double checked that build from my github repo builds.

Moreover, I've launched (loaded only - failed at execution) xcrun from Xcode 7.2 (which means all symbols are included now), so probably after implementing some functions it should launch - making Xcode tools usable without typing path.