### PR TITLE
cmake: make sure the correct linker is used

### DIFF
--- a/cmake/use_ld64.cmake
+++ b/cmake/use_ld64.cmake
@@ -1,5 +1,10 @@
 FUNCTION(use_ld64 target)
 	set_property(TARGET ${target} APPEND_STRING PROPERTY
+		COMPILE_FLAGS " -fuse-ld=${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/ld64/src/x86_64-apple-darwin11-ld ")
+	set_property(TARGET ${target} APPEND_STRING PROPERTY
+		LINK_FLAGS " -fuse-ld=${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/ld64/src/x86_64-apple-darwin11-ld ")
+
+	set_property(TARGET ${target} APPEND_STRING PROPERTY
 		LINK_FLAGS " -B ${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/ld64/src/ \
 -B ${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/misc/ \
 -target x86_64-apple-darwin11 -Wl,-Z \


### PR DESCRIPTION
I figured out how to make CMake use the correct linker for all the cross compile targets. This patch fixes the issue I opened earlier.

fixes #554