### PR TITLE
Partially Fix #600

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,3 +22,6 @@ override_dh_fixperms:
 	chmod -R -x debian/darling-dkms/usr/src/darling-mach-0.1/lkm
 
 override_dh_update_autotools_config:
+
+override_dh_auto_install:
+	sudo $(MAKE) -j$(shell nproc) install


### PR DESCRIPTION
When building a Debian package ```src/setup-fonts.sh``` and ```src/setup-ld-so.sh``` are not run as root and fail, which cause the issue. These scripts would be better run during installation instead of packaging.