### PR TITLE
Fix issue with setup-fonts.sh

### DIFF
--- a/src/setup-fonts.sh
+++ b/src/setup-fonts.sh
@@ -6,9 +6,13 @@
 root=/Volumes/SystemRoot
 
 for file in $(find /etc/fonts/ -type f); do
+    mkdir -p $(dirname .$file)
     sed "s|/usr/|$root/usr/|" $file > .$file
 done
 
 for link in $(find /etc/fonts/ -type l); do
-    [ -L .$link ] || ln -s $root$(realpath $link) .$link
+    if [[ ! -L .$link ]]; then
+        mkdir -p $(dirname .$link)
+        ln -s $root$(realpath $link) .$link
+    fi
 done


### PR DESCRIPTION
This solves:
```
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/70-no-bitmaps.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-khmer.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/64-language-selector-prefer.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-sub-pixel-rgb.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-sub-pixel-bgr.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-hinting-slight.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-hinting-none.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-serif.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-gujarati.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-suruma.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-sans-mono.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/30-droid-noto.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-chilanka.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-unifont.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/49-sansserif.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/45-latin.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-smc-meera.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-ja.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-assamese.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-lohit-malayalam.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-bengali.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-fonts-persian.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-dyuthi.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-zh-sg.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-hinting-full.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans-mono.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/70-force-bitmaps.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-anjalioldlipi.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-telu-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/11-lcdfilter-default.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-smc-rachana.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/70-yes-bitmaps.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-deva-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/99-language-selector-zh.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/53-monospace-lcd-filter.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-zh-cn.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-sub-pixel-vrgb.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/90-synthetic.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-tamil.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-telugu.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-hinting-medium.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/30-metric-aliases.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-serif.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-zh-mo.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-keraleeyam.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-gubbi.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/30-droid-noto-mono.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-antialias.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/51-local.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/80-delicious.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/60-generic.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/57-dejavu-sans.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-guru-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-pagul.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/50-user.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-autohint.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-scale-bitmap-fonts.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-orya-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-unhinted.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/58-dejavu-lgc-sans.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/11-lcdfilter-legacy.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-sub-pixel-vbgr.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-fonts-smc-manjari.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/45-generic.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/58-dejavu-lgc-sans-mono.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/30-cjk-aliases.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-beng-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/60-latin.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-tamil-classical.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-vera.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-0-fonts-gujr-extra.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/57-dejavu-serif.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-kannada.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-odia.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-nonlatin.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-raghumalayalamsans.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/25-unhint-nonlatin.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/57-dejavu-sans-mono.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/40-nonlatin.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-zh-hk.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/10-no-sub-pixel.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/20-unhint-small-dejavu-sans.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-uroob.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-gurmukhi.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/69-language-selector-zh-tw.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/67-smc-karumbi.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/59-lohit-devanagari.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/65-droid-sans-fallback.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/11-lcdfilter-light.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/58-dejavu-lgc-serif.conf: No such file or directory
/usr/lib/darling/setup-fonts.sh: line 9: ./etc/fonts/conf.avail/66-lohit-devanagari.conf: No such file or directory
```