### PR TITLE
--exclude-vcs Breaks the DSC Build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Lubos Dolezel <lubos@dolezel.info>
 Section: misc
 Priority: optional
 Standards-Version: 4.4.0
-Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build
+Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build, python2
 
 Package: darling
 Architecture: amd64

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 %:
-	dh $@ --builddirectory=debbuild --parallel
+	dh $@ --builddirectory=debbuild
 
 override_dh_auto_configure:
 	mkdir debbuild

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -2,3 +2,5 @@ darling source: configure-generated-file-in-source *
 darling source: autotools-pkg-config-macro-not-cross-compilation-safe *
 darling source: source-contains-prebuilt-windows-binary *
 darling source: maintainer-script-lacks-debhelper-token debian/*
+darling source: debhelper-but-no-misc-depends darling-dkms
+darling source: package-needs-versioned-debhelper-build-depends 10

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -3,7 +3,7 @@ set -e
 
 DATE=$(date +%Y%m%d)
 rm -f debian/changelog
-EDITOR=true NAME="Darling build server" EMAIL=noreply@darlinghq.org dch -u low -v 0.1.${DATE} --create --distribution testing --package darling "Daily build"
+EDITOR=true NAME="Darling build server" EMAIL=${DEB_EMAIL:-noreply@darlinghq.org} dch -u low -v 0.1.${DATE} --create --distribution ${DEB_DISTRO:-testing} --package darling "Daily build"
 
 if [ "$1" = "--dsc" ]; then
     ARG='-S'

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -3,14 +3,16 @@ set -e
 
 DATE=$(date +%Y%m%d)
 rm -f debian/changelog
-EDITOR=true NAME="Darling build server" EMAIL=${DEB_EMAIL:-noreply@darlinghq.org} dch -u low -v 0.1.${DATE} --create --distribution ${DEB_DISTRO:-testing} --package darling "Daily build"
+DISTRO=${DEB_DISTRO:-testing}
+VERSION=0.1.${DATE}~${DISTRO}
+EDITOR=true NAME="Darling build server" EMAIL=${DEB_EMAIL:-noreply@darlinghq.org} dch -u low -v ${VERSION} --create --distribution ${DISTRO} --package darling "Daily build"
 
 if [ "$1" = "--dsc" ]; then
     ARG='-S'
-    if [ -e "../darling_0.1.${DATE}.orig.tar.xz" ]; then
-        rm ../darling_0.1.${DATE}.orig.tar.xz
+    if [ -e "../darling_${VERSION}.orig.tar.xz" ]; then
+        rm ../darling_${VERSION}.orig.tar.xz
     fi
-    tar -cJf ../darling_0.1.${DATE}.orig.tar.xz .
+    tar -cJf ../darling_${VERSION}.orig.tar.xz .
 else
     ARG='-b'
 fi

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -10,9 +10,7 @@ if [ "$1" = "--dsc" ]; then
     if [ -e "../darling_0.1.${DATE}.orig.tar.xz" ]; then
         rm ../darling_0.1.${DATE}.orig.tar.xz
     fi
-    tar --exclude-vcs --exclude-vcs-ignores -cf ../darling_0.1.${DATE}.orig.tar .
-    tar -rf ../darling_0.1.${DATE}.orig.tar debian/changelog
-    xz ../darling_0.1.${DATE}.orig.tar
+    tar -cJf ../darling_0.1.${DATE}.orig.tar.xz .
 else
     ARG='-b'
 fi


### PR DESCRIPTION
Because some submodues have files that would have been gitignored in the main repo, but aren't in their repo, the build fails, because the archive and folder are different.