### PR TITLE
Fix Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Lubos Dolezel <lubos@dolezel.info>
 Section: misc
 Priority: optional
 Standards-Version: 4.4.0
-Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build, python2
+Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build, python
 
 Package: darling
 Architecture: amd64

--- a/debian/darling.prerm
+++ b/debian/darling.prerm
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -e
 
+echo ">>> Shutting down old instances of Darling"
+bash /usr/lib/darling/shutdown-user.sh
+
+echo ">>> Deleting old configuration files"
 rm -rf /usr/libexec/darling/etc/fonts
 rm -rf /usr/libexec/darling/etc/ld.so.conf.d/
+rm -f /usr/libexec/darling/etc/ld.so.*


### PR DESCRIPTION
The ```python2``` package is only available on Ubuntu 19.04 and above and the ```python``` package is always available and also Python 2.