### PR TITLE
Fixing Debian build dependency with linux headers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Lubos Dolezel <lubos@dolezel.info>
 Section: misc
 Priority: optional
 Standards-Version: 4.4.0
-Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build, python, libxrandr-dev, libxcursor-dev, libgif-dev
+Build-Depends: cmake, clang, bison, flex, libfuse-dev, libudev-dev, pkg-config, libc6-dev-i386, linux-headers-amd64|linux-headers-generic, gcc-multilib, libcairo2-dev, libgl1-mesa-dev, libtiff5-dev, libfreetype6-dev, libelf-dev, libxml2-dev, libegl1-mesa-dev, libfontconfig1-dev, libbsd-dev, debhelper, ninja-build, python, libxrandr-dev, libxcursor-dev, libgif-dev
 
 Package: darling
 Architecture: amd64


### PR DESCRIPTION
Adding the closest equivalent to Ubuntu's linux-headers-generic in Debian, which is linux-headers-amd64.