### PR TITLE
Fix #728

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ under [releases](https://github.com/darlinghq/darling/releases).
 
 ## Build Instructions
 
-For build instructions, visit [DarlingHQ Wiki](https://wiki.darlinghq.org/build_instructions).
+For build instructions, visit [Darling Docs](http://docs.darlinghq.org/build-instructions.html).
 
 ### Prefixes
 


### PR DESCRIPTION
This fixes #728 where the link to the build instructions in the `readme.md` is broken by updating it to the new link, and also changing it from `DarlingHQ Wiki` to `Darling Docs`.