### PR TITLE
Add a dummy implementation of csops in userspace

### DIFF
--- a/src/kernel/emulation/linux/CMakeLists.txt
+++ b/src/kernel/emulation/linux/CMakeLists.txt
@@ -172,6 +172,7 @@ set(emulation_sources
 	misc/setlogin.c
 	misc/reboot.c
 	misc/iopolicysys.c
+	misc/csops.c
 	fcntl/open.c
 	fcntl/openat.c
 	fcntl/fcntl.c

--- a/src/kernel/emulation/linux/misc/csops.c
+++ b/src/kernel/emulation/linux/misc/csops.c
@@ -1,0 +1,31 @@
+#include "csops.h"
+#include <stdint.h>
+#include <sys/codesign.h>
+#include "../duct_errno.h"
+#include <strings.h>
+
+// TODO: actually implement this
+// this is just a dummy implementation for now that returns no actual data for any operation
+long sys_csops(int pid, unsigned int ops, void* useraddr, size_t usersize) {
+	int ret = 0;
+
+	switch (ops) {
+		case CS_OPS_STATUS: {
+			*(uint32_t*)useraddr = CS_VALID;
+		} break;
+
+		case CS_OPS_BLOB:
+		case CS_OPS_ENTITLEMENTS_BLOB:
+		case CS_OPS_IDENTITY: {
+			memset(useraddr, 0, usersize);
+		} break;
+
+		// all other operations are completely unsupported
+		default: {
+			ret = -1;
+			errno = ENOSYS;
+		} break;
+	}
+
+	return ret;
+};

--- a/src/kernel/emulation/linux/misc/csops.h
+++ b/src/kernel/emulation/linux/misc/csops.h
@@ -1,0 +1,8 @@
+#ifndef LINUX_CSOPS_H
+#define LINUX_CSOPS_H
+
+#include <stddef.h>
+
+long sys_csops(int pid, unsigned int ops, void* useraddr, size_t usersize);
+
+#endif // LINUX_CSOPS_H

--- a/src/kernel/emulation/linux/syscalls.c
+++ b/src/kernel/emulation/linux/syscalls.c
@@ -118,6 +118,7 @@
 #include "misc/gethostuuid.h"
 #include "misc/getrusage.h"
 #include "misc/syscall.h"
+#include "misc/csops.h"
 #include "synch/semwait_signal.h"
 #include "fcntl/open.h"
 #include "fcntl/openat.h"
@@ -309,6 +310,7 @@ void* __bsd_syscall_table[600] = {
 	[157] = sys_statfs,
 	[158] = sys_fstatfs,
 	[159] = sys_unmount,
+	[169] = sys_csops,
 	[173] = sys_waitid,
 	[181] = sys_setgid,
 	[182] = sys_setegid,


### PR DESCRIPTION
The real csops would need for the LKM to store codesigning information, entitlements, and more. This is a simple dummy implementation that returns valid data instead of having an unimplemented syscall.