### PR TITLE
Implement csrctl

### DIFF
--- a/src/kernel/emulation/linux/CMakeLists.txt
+++ b/src/kernel/emulation/linux/CMakeLists.txt
@@ -175,6 +175,7 @@ set(emulation_sources
 	misc/csops.c
 	misc/fileport_makeport.c
 	misc/fileport_makefd.c
+	misc/csrctl.c
 	fcntl/open.c
 	fcntl/openat.c
 	fcntl/fcntl.c

--- a/src/kernel/emulation/linux/misc/csrctl.c
+++ b/src/kernel/emulation/linux/misc/csrctl.c
@@ -1,0 +1,20 @@
+#include "csrctl.h"
+#include "../duct_errno.h"
+#define PRIVATE
+#include <sys/csr.h>
+
+long sys_csrctl(uint32_t op, void* useraddr, size_t usersize) {
+	switch (op) {
+		case CSR_SYSCALL_CHECK: {
+			// allow everything
+			return 0;
+		} break;
+		case CSR_SYSCALL_GET_ACTIVE_CONFIG: {
+			// set everything to "allowed"
+			*(uint32_t*)useraddr = CSR_VALID_FLAGS;
+			return 0;
+		} break;
+		default:
+			return ENOSYS;
+	}
+};

--- a/src/kernel/emulation/linux/misc/csrctl.h
+++ b/src/kernel/emulation/linux/misc/csrctl.h
@@ -1,0 +1,9 @@
+#ifndef LINUX_CSRCTL_H
+#define LINUX_CSRCTL_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+long sys_csrctl(uint32_t op, void* useraddr, size_t usersize);
+
+#endif // LINUX_CSRCTL_H

--- a/src/kernel/emulation/linux/syscalls.c
+++ b/src/kernel/emulation/linux/syscalls.c
@@ -121,6 +121,7 @@
 #include "misc/csops.h"
 #include "misc/fileport_makeport.h"
 #include "misc/fileport_makefd.h"
+#include "misc/csrctl.h"
 #include "synch/semwait_signal.h"
 #include "fcntl/open.h"
 #include "fcntl/openat.h"
@@ -463,6 +464,7 @@ void* __bsd_syscall_table[600] = {
 	[474] = sys_symlinkat,
 	[475] = sys_mkdirat,
 	[476] = sys_getattrlistat,
+	[483] = sys_csrctl,
 	[500] = sys_getentropy,
 	[515] = sys_ulock_wait,
 	[516] = sys_ulock_wake,


### PR DESCRIPTION
Syscall 483, used to indicate what parts of SIP are enabled. This implementation just returns a value indicating full, unrestricted access (i.e. no SIP).