### PR TITLE
fixes breakage from recent "CGS work in progress"

### DIFF
--- a/src/frameworks/ApplicationServices/HIServices/src/HIServices.c
+++ b/src/frameworks/ApplicationServices/HIServices/src/HIServices.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <LaunchServices/LaunchServicesPriv.h>
-#include <CoreGraphics/CGS.h>
+#include <CoreGraphics/CoreGraphicsPrivate.h>
 
 const CFStringRef kAXUIElementCopyHierarchyArrayAttributesKey = CFSTR("AXCHAA");
 const CFStringRef kAXUIElementCopyHierarchyMaxArrayCountKey = CFSTR("AXCHMAC");


### PR DESCRIPTION
===
commit e135e3d15e0d48e62b1e76db0b8c58fb0f07d5f7
Author: Lubos Dolezel <lubos@dolezel.info>
Date:   Fri May 15 12:40:44 2020 +0200

    Update the cocotron submodule
===

pulled in

===
commit b26bedb31c8c770622c1ad0ab28b577dffa0b091
Author: Lubos Dolezel <lubos@dolezel.info>
Date:   Fri May 15 10:47:23 2020 +0200

    CGS work progress

===

which deletes CoreGraphics/CGS.h, which is needed by
src/frameworks/ApplicationServices/HIServices/src/HIServices.c .

fixes https://github.com/darlinghq/darling/issues/795