### PR TITLE
Auto-Calculate Darling Prefix in tools/uninstall

### DIFF
--- a/tools/uninstall
+++ b/tools/uninstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set +e
 
 if [ "$(whoami)" != "root" ]
@@ -8,15 +8,17 @@ then
 	exit
 fi
 
+DARLING_PREFIX="$(dirname "$(dirname "$(which darling)")")"
+
 if command -v darling
 then
 	darling shutdown
 fi
-if [ -d /usr/local/libexec ]
+if [ -d "${DARLING_PREFIX}/libexec" ]
 then
-	rm -rf /usr/local/libexec/darling
-	rmdir --ignore-fail-on-non-empty /usr/local/libexec
+	rm -rf "${DARLING_PREFIX}/libexec/darling"
+	rmdir --ignore-fail-on-non-empty "${DARLING_PREFIX}/libexec"
 fi
-rm -f /usr/local/bin/darling
+rm -f "${DARLING_PREFIX}/bin/darling"
 find /lib/modules -name darling-mach.ko -delete
 echo "Uninstall complete"

--- a/tools/uninstall
+++ b/tools/uninstall
@@ -8,17 +8,17 @@ then
 	exit
 fi
 
-DARLING_PREFIX="$(dirname "$(dirname "$(which darling)")")"
+INSTALL_PREFIX="$(dirname "$(dirname "$(which darling)")")"
 
 if command -v darling
 then
 	darling shutdown
 fi
-if [ -d "${DARLING_PREFIX}/libexec" ]
+if [ -d "${INSTALL_PREFIX}/libexec" ]
 then
-	rm -rf "${DARLING_PREFIX}/libexec/darling"
-	rmdir --ignore-fail-on-non-empty "${DARLING_PREFIX}/libexec"
+	rm -rf "${INSTALL_PREFIX}/libexec/darling"
+	rmdir --ignore-fail-on-non-empty "${INSTALL_PREFIX}/libexec"
 fi
-rm -f "${DARLING_PREFIX}/bin/darling"
+rm -f "${INSTALL_PREFIX}/bin/darling"
 find /lib/modules -name darling-mach.ko -delete
 echo "Uninstall complete"


### PR DESCRIPTION
Also switched the shebang to ```/bin/sh```  since the script seemed ```sh``` compatible, and there are faster ```sh``` implementations than ```bash``` like ```dash```.