### PR TITLE
Avoid out of range array access.

### DIFF
--- a/src/kernel/emulation/linux/errno.c
+++ b/src/kernel/emulation/linux/errno.c
@@ -1,6 +1,7 @@
 #include "errno.h"
 #include "base.h"
 #include "duct_errno.h"
+#include <stddef.h>
 
 static const int linux_to_darwin[512] = {
 
@@ -90,6 +91,7 @@ static const int linux_to_darwin[512] = {
 	[LINUX_ETIME] = ETIME,
 	[LINUX_EOPNOTSUPP] = EOPNOTSUPP,
 };
+const size_t length_of_translation_array = sizeof(linux_to_darwin)/sizeof(const int);
 
 int errno_linux_to_bsd(int err)
 {
@@ -97,7 +99,7 @@ int errno_linux_to_bsd(int err)
 	if (v < 0)
 		v = -v;
 
-	if (linux_to_darwin[v])
+	if ((v < length_of_translation_array) && (linux_to_darwin[v]))
 	{
 		v = linux_to_darwin[v];
 		return (err < 0) ? -v : v;


### PR DESCRIPTION
Simple changes to avoid possible out-of-range array access in errno_linux_to_bsd().  Should require little to no maintenance as it simply calculates the size of the array and then compares the index to the size before making an access. 