### PR TITLE
Rpm auto version

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -17,7 +17,9 @@ RUN dnf install -y bison cairo-devel clang cmake dkms flex fontconfig-devel.x86_
                    python2 systemd-devel make libxml2-devel elfutils-libelf-devel \
                    libbsd-devel ffmpeg-devel pulseaudio-libs-devel openssl-devel \
                    giflib-devel libXrandr-devel libXcursor-devel libxkbfile-devel \
-                   dbus-devel mesa-libGLU-devel; \
+                   dbus-devel mesa-libGLU-devel \
+                   # git - so I can determine the date of the last commit
+                   git; \
     dnf clean all
 
 RUN mkdir -p /root/rpmbuild/SOURCES

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf install -y bison cairo-devel clang cmake dkms flex fontconfig-devel.x86_
                    libbsd-devel ffmpeg-devel pulseaudio-libs-devel openssl-devel \
                    giflib-devel libXrandr-devel libXcursor-devel libxkbfile-devel \
                    dbus-devel mesa-libGLU-devel \
-                   # git - so I can determine the date of the last commit
+                   # git - so I can determine the describe of the last commit, not an rpm dependency
                    git; \
     dnf clean all
 

--- a/rpm/SOURCES/dkms.conf
+++ b/rpm/SOURCES/dkms.conf
@@ -1,5 +1,6 @@
 PACKAGE_NAME=darling-mach
-PACKAGE_VERSION=0.1.20200331
+# PACKAGE_VERSION is rewritten by the darling.spec file, so this value is really a place holder
+PACKAGE_VERSION=0.1
 BUILT_MODULE_NAME="$PACKAGE_NAME"
 BUILT_MODULE_LOCATION=lkm/
 DEST_MODULE_LOCATION[0]=/extra

--- a/rpm/SPECS/darling.spec
+++ b/rpm/SPECS/darling.spec
@@ -4,11 +4,11 @@
 %define debug_package %{nil}
 %define commit_date %{getenv:DARLING_COMMIT_DATE}
 %if "%{commit_date}" == ""
-  %define commit_date 20210129
+  %define commit_date 0
 %endif
 
 Name:           darling
-Version:        0.1.%{commit_date}%{!?commit_date:20210129}
+Version:        0.1.%{commit_date}
 Release:        1%{?dist}
 Summary:        Darling
 

--- a/rpm/SPECS/darling.spec
+++ b/rpm/SPECS/darling.spec
@@ -2,9 +2,13 @@
 %global __os_install_post %{nil}
 #Disable debug packages, since these are emulated files mostly
 %define debug_package %{nil}
+%define commit_date %{getenv:DARLING_COMMIT_DATE}
+%if "%{commit_date}" == ""
+  %define commit_date 20210129
+%endif
 
 Name:           darling
-Version:        0.1.20200331
+Version:        0.1.%{commit_date}%{!?commit_date:20210129}
 Release:        1%{?dist}
 Summary:        Darling
 
@@ -69,7 +73,8 @@ cp -dr --no-preserve=ownership build/src/external/lkm/osfmk %{?buildroot}/usr/sr
 # Copy rtsig.h
 cp -dr --no-preserve=ownership build/src/startup/rtsig.h %{?buildroot}/usr/src/%{name}-mach-%{version}/lkm/darling/
 
-%{__install} -m 644 %{SOURCE1} %{?buildroot}/usr/src/%{name}-mach-%{version}
+sed 's|^PACKAGE_VERSION=.*|PACKAGE_VERSION=%{version}|' %{SOURCE1} > dkms.conf
+%{__install} -m 644 dkms.conf %{?buildroot}/usr/src/%{name}-mach-%{version}
 
 # https://github.com/dell/dkms/issues/25
 %preun mach

--- a/rpm/build.bsh
+++ b/rpm/build.bsh
@@ -10,5 +10,14 @@ else
   tar --transform "s|^\./|./darling/|" -cf /root/rpmbuild/SOURCES/darling.tar.gz -C /src --exclude=.git --exclude SOURCES --exclude SRPMS --exclude RPMS .
 fi
 ln -s /src/rpm/SOURCES/dkms.conf /root/rpmbuild/SOURCES/
+
+DARLING_COMMIT_DATE="$(cd /src; git show -s --format=%cs HEAD)"
+DARLING_COMMIT_DATE="${DARLING_COMMIT_DATE//-/}"
+
+if [ -z "${DARLING_COMMIT_DATE}" ]; then
+  DARLING_COMMIT_DATE="$(date +%Y%m%d)"
+fi
+export DARLING_COMMIT_DATE
+
 #spectool -g -R /src/rpm/SPECS/darling.spec
 rpmbuild -ba /src/rpm/SPECS/darling.spec

--- a/rpm/build.bsh
+++ b/rpm/build.bsh
@@ -11,13 +11,8 @@ else
 fi
 ln -s /src/rpm/SOURCES/dkms.conf /root/rpmbuild/SOURCES/
 
-DARLING_COMMIT_DATE="$(cd /src; git show -s --format=%cs HEAD)"
-DARLING_COMMIT_DATE="${DARLING_COMMIT_DATE//-/}"
-
-if [ -z "${DARLING_COMMIT_DATE}" ]; then
-  DARLING_COMMIT_DATE="$(date +%Y%m%d)"
-fi
-export DARLING_COMMIT_DATE
+DARLING_COMMIT_DATE="$(cd /src; git describe --tags HEAD)"
+export DARLING_COMMIT_DATE="${DARLING_COMMIT_DATE//-/}"
 
 #spectool -g -R /src/rpm/SPECS/darling.spec
 rpmbuild -ba /src/rpm/SPECS/darling.spec


### PR DESCRIPTION
Was trying to rebuild the latest version of darling, but I made a mistake and it didn't build. Currently, the "version" on rpms is `0.1.{date}`. So if that ever needs to get updated, then I would have to update the spec file (and dkms.conf) and PR that each time. Instead, now the build script will auto detect the latest commit date, and use that for the version number, making this one less thing to worry about :)

**Expected Result**
Kernel module build successfully.

**Actual Result**
Error while compiling, make.log shows:

```bash
/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/ipc/ipc_kmsg.c:84:10: fatal error: mach/vm_map.h: No such file or directory
```

**Steps To Reproduce**
1. `docker-compose run rpm`
2. `sudo install RPMS/x86_64/*20210123*.rpm`
3. (optional) dkms build darling/0.1.20210123-1

**``dmesg`` Output**

N/A

**System Information**
What system are you using?

| Software | Version |
| --- | --- |
| Linux Kernel | 5.8.18-100.fc31.x86_64 |
| Darling | f866083413b7387e5f9532811d74abe375a2f669 |

**debugging**

1. `dkms make darling/0.1.20210123`

```
Kernel preparation unnecessary for this kernel.  Skipping...

Building module:
cleaning build area...
'make' -C lkm/ MIGDIR=/usr/src/darling-mach-0.1.20200331/miggen MIGDIR_REL=../miggen KERNELVERSION=5.8.18-100.fc31.x86_64....(bad exit status: 2)
Error! Bad return status for module build on kernel: 5.8.18-100.fc31.x86_64 (x86_64)
Consult /var/lib/dkms/darling-mach/0.1.20210123/build/make.log for more information.
```

2. `cd /var/lib/dkms/darling-mach/0.1.20210123/build`
3. `make -C lkm/ SHELL='sh -xv' MIGDIR=/usr/src/darling-mach-0.1.20200331/miggen MIGDIR_REL=../miggen KERNELVERSION=5.8.18-100.fc31.x86_64`

Offending command:

```bash
  CC [M]  /var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/ipc/ipc_kmsg.o
+ gcc -Wp,-MMD,/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/ipc/.ipc_kmsg.o.d -nostdinc -isystem /usr/lib/gcc/x86_64-redhat-linux/9/include -I./arch/x86/include -I./arch/x86/include/generated -I./include -I./arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I./include/uapi -I./include/generated/uapi -include ./include/linux/kconfig.h -include ./include/linux/compiler_types.h -D__KERNEL__ -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE -Werror=implicit-function-declaration -Werror=implicit-int -Wno-format-security -Wno-address-of-packed-member -std=gnu89 -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -m64 -falign-jumps=1 -falign-loops=1 -mno-80387 -mno-fp-ret-in-387 -mpreferred-stack-boundary=3 -mskip-rax-setup -mtune=generic -mno-red-zone -mcmodel=kernel -Wno-sign-compare -fno-asynchronous-unwind-tables -mindirect-branch=thunk-extern -mindirect-branch-register -fno-jump-tables -fno-delete-null-pointer-checks -Wno-frame-address -Wno-format-truncation -Wno-format-overflow -Wno-address-of-packed-member -O2 --param=allow-store-data-races=0 -Wframe-larger-than=2048 -fstack-protector -Wno-unused-but-set-variable -Wimplicit-fallthrough -Wno-unused-const-variable -fno-var-tracking-assignments -g -pg -mrecord-mcount -mfentry -DCC_USING_FENTRY -Wdeclaration-after-statement -Wvla -Wno-pointer-sign -Wno-stringop-truncation -Wno-array-bounds -Wno-stringop-overflow -Wno-restrict -Wno-maybe-uninitialized -fno-strict-overflow -fno-merge-all-constants -fmerge-constants -fno-stack-check -fconserve-stack -Werror=date-time -Werror=incompatible-pointer-types -Werror=designated-init -fmacro-prefix-map=./= -fcf-protection=none -Wno-packed-not-aligned -D__DARLING__ -DDARLING_DEBUG -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/EXTERNAL_HEADERS -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/EXTERNAL_HEADERS/bsd -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/duct/defines -DPAGE_SIZE_FIXED -DCONFIG_SCHED_TRADITIONAL -freorder-blocks -fno-builtin -fno-common -fsigned-bitfields -fno-strict-aliasing -fno-keep-inline-functions -Wno-unknown-pragmas -DAPPLE -DKERNEL -DKERNEL_PRIVATE -DXNU_KERNEL_PRIVATE -DPRIVATE -D__MACHO__=1 -Dvolatile=__volatile -DNEXT -Wno-error=cast-align -Wno-unused-parameter -Wno-missing-prototypes -Wno-unused-variable -D__LITTLE_ENDIAN__=1 -Wno-declaration-after-statement -Wno-undef -Wno-maybe-uninitialized -D__private_extern__=extern -D_MODE_T -D_NLINK_T -DVM32_SUPPORT=1 -DMACH_KERNEL_PRIVATE -I/usr/src/darling-mach-0.1.20200331/miggen/bsd -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/bsd -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/iokit -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/libkern -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/libsa -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/libsa -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/pexpert -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/security -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/export-headers -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/libsa -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/mach_debug -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/ -I/var/lib/dkms/darling-mach/0.1.20210123/build/lkm/darling -I/usr/src/darling-mach-0.1.20200331/miggen/osfmk -I/usr/src/darling-mach-0.1.20200331/miggen/../../startup -DARCH_PRIVATE -DDRIVER_PRIVATE -D_KERNEL_BUILD -DKERNEL_BUILD -DMACH_KERNEL -DBSD_BUILD -DBSD_KERNEL_PRIVATE -DLP64KERN=1 -DLP64_DEBUG=0 -DTIMEZONE=0 -DPST=0 -DQUOTA -DABSOLUTETIME_SCALAR_TYPE -DCONFIG_LCTX -DMACH -DCONFIG_ZLEAKS -DNO_DIRECT_RPC -DIPFIREWALL_FORWARD -DIPFIREWALL_DEFAULT_TO_ACCEPT -DTRAFFIC_MGT -DRANDOM_IP_ID -DTCP_DROP_SYNFIN -DICMP_BANDLIM -DIFNET_INPUT_SANITY_CHK -DPSYNCH -DSECURE_KERNEL -DOLD_SEMWAIT_SIGNAL -DCONFIG_MBUF_JUMBO -DCONFIG_WORKQUEUE -DCONFIG_HFS_STD -DCONFIG_HFS_TRIM -DCONFIG_TASK_MAX=512 -DCONFIG_IPC_TABLE_ENTRIES_STEPS=256 -DNAMEDSTREAMS -DCONFIG_VOLFS -DCONFIG_IMGSRC_ACCESS -DCONFIG_TRIGGERS -DCONFIG_VFS_FUNNEL -DCONFIG_EXT_RESOLVER -DCONFIG_SEARCHFS -DIPSEC -DIPSEC_ESP -DIPV6FIREWALL_DEFAULT_TO_ACCEPT -Dcrypto -Drandomipid -DCONFIG_KN_HASHSIZE=20 -DCONFIG_VNODES=750 -DCONFIG_VNODE_FREE_MIN=75 -DCONFIG_NC_HASH=1024 -DCONFIG_VFS_NAMES=2048 -DCONFIG_MAX_CLUSTERS=4 -DKAUTH_CRED_PRIMES_COUNT=3 '-DKAUTH_CRED_PRIMES={5, 17, 97}' -DCONFIG_MIN_NBUF=64 -DCONFIG_MIN_NIOBUF=32 '-DCONFIG_NMBCLUSTERS=((1024 * 256) / MCLBYTES)' -DCONFIG_TCBHASHSIZE=128 -DCONFIG_ICMP_BANDLIM=50 -DCONFIG_AIO_MAX=10 -DCONFIG_AIO_PROCESS_MAX=4 -DCONFIG_AIO_THREAD_COUNT=2 -DCONFIG_THREAD_MAX=1024 -DCONFIG_MAXVIFS=2 -DCONFIG_MFCTBLSIZ=16 -DCONFIG_MSG_BSIZE=4096 -DCONFIG_ENFORCE_SIGNED_CODE -DCONFIG_MEMORYSTATUS -DCONFIG_JETSAM -DCONFIG_FREEZE -DCONFIG_ZLEAK_ALLOCATION_MAP_NUM=8192 -DCONFIG_ZLEAK_TRACE_MAP_NUM=4096 -DVM_PRESSURE_EVENTS -DCONFIG_KERNEL_0DAY_SYSCALL_HANDLER -DEVENTMETER -DCONFIG_APP_PROFILE=0 -std=gnu11 -DMODULE '-DKBUILD_BASENAME="ipc_kmsg"' '-DKBUILD_MODNAME="darling_mach"' -c -o /var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/ipc/ipc_kmsg.o /var/lib/dkms/darling-mach/0.1.20210123/build/lkm/osfmk/ipc/ipc_kmsg.c
```

Some of the dirs say `0.1.20200331` instead of `0.1.20210123`

**Solution**
This was all due to `dkms.conf` not being updated too. In order to prevent this, we should auto generate the `dkms.conf` file when creating the RPM, so this mistake isn't made again