### PR TITLE
Update CMake supported clang versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ if (NOT DEFINED CMAKE_C_COMPILER)
 		"clang-7"
 		"clang-9"
 		"clang-10"
+		"clang-11"
+		"clang-12"
 )
 endif(NOT DEFINED CMAKE_C_COMPILER)
 
@@ -21,6 +23,8 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 		"clang++-7"
 		"clang++-9"
 		"clang++-10"
+		"clang++-11"
+		"clang++-12"
 )
 endif(NOT DEFINED CMAKE_CXX_COMPILER)
 


### PR DESCRIPTION
+ ~~Darling doesn't build with clang versions less than 9, so there is no need to support them: https://github.com/darlinghq/darling/issues/939 and https://github.com/darlinghq/darling/issues/964.~~ **EDIT:** Fixed by https://github.com/darlinghq/darling/commit/4fbf800df4dfa6e6159b2f97c8a053c9489e9dce.
+ Clang 11 is easier to get than 9 or 10 (buster-backports only has 8 and 11) so we should add it for ease of use.
+ Clang 12 support seems to be resolved: https://github.com/darlinghq/darling/issues/856.

~~I also updated the docs to reflect this change: https://github.com/darlinghq/darling-docs/pull/25~~