### PR TITLE
feat: Manage executable path in darlingserver

### DIFF
--- a/src/kernel/emulation/linux/misc/proc_info.c
+++ b/src/kernel/emulation/linux/misc/proc_info.c
@@ -646,11 +646,19 @@ static bool parse_smaps_firstline(
 static long _proc_pidinfo_pathinfo(int32_t pid, void* buffer, int32_t bufsize)
 {
 	struct vchroot_unexpand_args args;
+	uint64_t fullLength;
 
-	int rv = dserver_rpc_get_executable_path(pid, args.path, sizeof(args.path));
+	int rv = dserver_rpc_get_executable_path(pid, args.path, sizeof(args.path), &fullLength);
 
-	if (rv < 0)
-		return rv;
+	if (rv < 0) 
+	{
+		__simple_printf("dserver_rpc_get_executable_path failed internally: %d\n", rv);
+		__simple_abort();
+	}
+	else if (rv > 0) 
+	{
+		return -rv;
+	}
 
 	rv = vchroot_unexpand(&args);
 	if (rv != 0)

--- a/src/kernel/emulation/linux/misc/proc_info.c
+++ b/src/kernel/emulation/linux/misc/proc_info.c
@@ -645,20 +645,13 @@ static bool parse_smaps_firstline(
 
 static long _proc_pidinfo_pathinfo(int32_t pid, void* buffer, int32_t bufsize)
 {
-	char path[64];
 	struct vchroot_unexpand_args args;
 
-	__simple_sprintf(path, "/proc/%d/exe", pid);
-
-	memset(buffer, 0, bufsize);
-	int rv = sys_readlink(path, buffer, bufsize - 1);
+	int rv = dserver_rpc_get_executable_path(pid, args.path, sizeof(args.path));
 
 	if (rv < 0)
 		return rv;
 
-	((char*)buffer)[rv] = 0;
-
-	strcpy(args.path, buffer);
 	rv = vchroot_unexpand(&args);
 	if (rv != 0)
 		return rv;

--- a/src/startup/mldr/mldr.c
+++ b/src/startup/mldr/mldr.c
@@ -188,6 +188,8 @@ int main(int argc, char** argv, char** envp)
 		exit(1);
 	}
 
+	dserver_rpc_set_executable_path(filename, strlen(filename));
+
 	start_thread(&mldr_load_results);
 
 	__builtin_unreachable();

--- a/src/startup/mldr/mldr.c
+++ b/src/startup/mldr/mldr.c
@@ -188,8 +188,11 @@ int main(int argc, char** argv, char** envp)
 		exit(1);
 	}
 
-	dserver_rpc_set_executable_path(filename, strlen(filename));
-
+	if (dserver_rpc_set_executable_path(filename, strlen(filename)) < 0) {
+		fprintf(stderr, "Failed to tell darlingserver about our executable path\n");
+		exit(1);
+	}
+	
 	start_thread(&mldr_load_results);
 
 	__builtin_unreachable();


### PR DESCRIPTION
With darlingserver managing executable paths, `_proc_pidinfo_pathinfo` can get the path from darlingserver instead of procfs (which points to mldr instead of the real path).

Also, `mldr` now announces the executable path after loading and before starting the thread.