### PR TITLE
feat: Initial WSL1 support

### DIFF
--- a/src/kernel/emulation/linux/elfcalls_wrapper.c
+++ b/src/kernel/emulation/linux/elfcalls_wrapper.c
@@ -91,3 +91,15 @@ void __dserver_per_thread_socket_refresh(void) {
 void __dserver_close_socket(int socket) {
 	return elfcalls()->dserver_close_socket(socket);
 };
+
+int __dserver_get_process_lifetime_pipe() {
+	return elfcalls()->dserver_get_process_lifetime_pipe();
+}
+
+int __dserver_process_lifetime_pipe_refresh(void) {
+	return elfcalls()->dserver_process_lifetime_pipe_refresh();
+};
+
+void __dserver_close_process_lifetime_pipe(int* fds) {
+	return elfcalls()->dserver_close_process_lifetime_pipe(fds);
+};

--- a/src/kernel/emulation/linux/elfcalls_wrapper.h
+++ b/src/kernel/emulation/linux/elfcalls_wrapper.h
@@ -33,6 +33,10 @@ int __dserver_per_thread_socket(void);
 void __dserver_per_thread_socket_refresh(void);
 void __dserver_close_socket(int socket);
 
+int __dserver_get_process_lifetime_pipe(void);
+int __dserver_process_lifetime_pipe_refresh(void);
+void __dserver_close_process_lifetime_pipe(int* fds);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/startup/mldr/elfcalls/elfcalls.h
+++ b/src/startup/mldr/elfcalls/elfcalls.h
@@ -61,6 +61,11 @@ struct elf_calls
 	int (*dserver_per_thread_socket)(void);
 	void (*dserver_per_thread_socket_refresh)(void);
 	void (*dserver_close_socket)(int socket);
+
+	// darlingserver process lifetime pipe info
+	int (*dserver_get_process_lifetime_pipe)(void);
+	int (*dserver_process_lifetime_pipe_refresh)(void);
+	void (*dserver_close_process_lifetime_pipe)(int* fds);
 };
 
 #endif

--- a/src/startup/mldr/loader.h
+++ b/src/startup/mldr/loader.h
@@ -22,6 +22,7 @@ struct load_results {
 	unsigned long stack_top;
 	char* socket_path;
 	int kernfd;
+	int lifetime_pipe;
 
 	size_t argc;
 	size_t envc;


### PR DESCRIPTION
Part of https://github.com/darlinghq/darling/issues/1206.
Should not be reviewed/merged before https://github.com/darlinghq/darlingserver/pull/4.

- mldr: Replaced `mmap` calls with `compatible_mmap`, a function
that removes `MAP_GROWSDOWN` on incompatible systems, and emulates
`MAP_FIXED_NOREPLACE` on older kernels.
- mldr: Implemented lifetime pipes. These pipes are created during
process creation and sent to darlingserver. The pipe is preserved
through exec calls and automatically closes on process termination.
- kernel/emulation: `execve` now preserves mldr lifetime pipes through
the `__mldr_lifetime_pipe` environment variable.
- kernel/emulation: Parameters for calls to `dserver_rpc_checkin` have
been updated to reflect changes in darlingserver.