### PR TITLE
Fail Cmake configuration step if python2 not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endif(NOT DEFINED CMAKE_CXX_COMPILER)
 
 option(DARLING_NO_CCACHE "Disable ccache usage" OFF)
 
+find_package(Python2 REQUIRED COMPONENTS Interpreter)
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM AND NOT DARLING_NO_CCACHE)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")


### PR DESCRIPTION
When building on a system without a python2 interpreter, the build step failed, not the configuration step. An output like this is what I saw (`Ingen sådan fil eller filkatalog` = `No such file or file directory`):

```
FAILED: src/external/python_modules/Modules/six-1.12.0/six-1.12.0/six.pyc /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/six-1.12.0/six-1.12.0/six.pyc 
cd /home/milo/Udvikler/darling/src/external/python_modules/Modules/six-1.12.0/six-1.12.0 && /home/milo/Udvikler/darling/tools/pyc six.py /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/six-1.12.0/six-1.12.0//six.pyc
/usr/bin/env: "python2": Ingen sådan fil eller filkatalog
[3714/26232] Generating macholib/MachOGraph.pyc
FAILED: src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOGraph.pyc /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOGraph.pyc 
cd /home/milo/Udvikler/darling/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1 && /home/milo/Udvikler/darling/tools/pyc macholib/MachOGraph.py /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOGraph.pyc
/usr/bin/env: "python2": Ingen sådan fil eller filkatalog
[3716/26232] Generating macholib/MachO.pyc
FAILED: src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachO.pyc /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachO.pyc 
cd /home/milo/Udvikler/darling/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1 && /home/milo/Udvikler/darling/tools/pyc macholib/MachO.py /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachO.pyc
/usr/bin/env: "python2": Ingen sådan fil eller filkatalog
[3717/26232] Generating macholib/MachOStandalone.pyc
FAILED: src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOStandalone.pyc /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOStandalone.pyc 
cd /home/milo/Udvikler/darling/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1 && /home/milo/Udvikler/darling/tools/pyc macholib/MachOStandalone.py /home/milo/Udvikler/darling/build/src/external/python_modules/Modules/macholib-1.5.1/macholib-1.5.1/macholib/MachOStandalone.pyc
/usr/bin/env: "python2": Ingen sådan fil eller filkatalog
```

Installing a python2 interpreter fixed the issue. The change I made to the root `CMakeLists.txt` requires a valid python2 interpreter to be installed on the machine.