### PR TITLE
Increase Cmake minimum version to 3.13, bump darlingserver submodule version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "The version of macOS we're s
 
 project(darling)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 enable_language(ASM)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Does virtually the same thing as #1229. That PR is stagnant, however, as the author has not responded by bumping a sub module version. This PR bumps the module version. Useful output from `git submodule status | grep darlingserver`:

```
 697fa6e643f0d7c44f5db2143f266345efb37136 src/external/darlingserver (heads/main)
```

While commit `697fa6e643f0d7c44f5db2143f266345efb37136` is the latest, and is after the commit where darlingserver got updated to version 3.13 (see commit `e9e0a9f9a4acdcc0150e90dbb0ed92f107904ebe`), the delta code change between the two shouldn't break anything as the only things changed were bug fixes (one for int-conversion and one to use explicit casting).