### PR TITLE
Rewrite LSINFO getDatabaseQueue in LaunchServices to be Threadsafe

### DIFF
--- a/src/frameworks/CoreServices/src/LaunchServices/LSInfo.m
+++ b/src/frameworks/CoreServices/src/LaunchServices/LSInfo.m
@@ -28,11 +28,11 @@ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 __attribute__((visibility("hidden")))
 FMDatabaseQueue* getDatabaseQueue(void)
 {
-	static FMDatabaseQueue* db = nil;
-	if (!db)
-	{
+	static dispatch_once_t pred;
+	static FMDatabaseQueue* db;
+	dispatch_once(&pred, ^{
 		db = [[FMDatabaseQueue databaseQueueWithPath: @"/private/var/db/launchservices.db" flags:SQLITE_OPEN_READONLY] retain];
-	}
+	});
 	return db;
 }
 


### PR DESCRIPTION
rewrote `getDatabaseQueue` to be thread safe using `dispatch_once` as part of improvements to AppKit