### PR TITLE
libm: Remove unused rpath config

### DIFF
--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -156,10 +156,6 @@ endif ()
 # Gross hack to rename symbols in $fenv_access_off variants
 set(CMAKE_AR "${CMAKE_CURRENT_SOURCE_DIR}/rename_wrapper")
 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/darling")
-SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) 
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 if (TARGET_i386 OR TARGET_x86_64)
 	add_darling_object_library(system_m_extra Source/Intel/xmm_misc.c Source/Intel/xmm_log.c Source/Intel/fmaxfminfdim.S Source/Intel/nextafter.S Source/Intel/xmm_remainder.c Source/Intel/e_remquol.S)
 	set_target_properties(system_m_extra PROPERTIES COMPILE_FLAGS "-UBUILDING_FOR_CARBONCORE_LEGACY -O0 -ggdb")


### PR DESCRIPTION
Doesn't seem to be necessary.

<details>
<summary>Original PR description</summary>

The rpath is resolved within the Darling sandbox, not from the install location.

Anyways, I don't think it's needed at all at the moment.
</details>