### PR TITLE
Coredump: Migrate To C++ & Bug Fix

### DIFF
--- a/src/hosttools/CMakeLists.txt
+++ b/src/hosttools/CMakeLists.txt
@@ -3,7 +3,11 @@ project(hosttools)
 option(DARLING_COREDUMP_SANITIZE "Enable/disable ASAN and UBSAN in darling-coredump" OFF)
 
 add_executable(darling-coredump
-	src/coredump/main.c
+	src/coredump/main.cpp
+)
+
+target_compile_options(darling-coredump PRIVATE
+	-std=c++17
 )
 
 target_include_directories(darling-coredump PRIVATE


### PR DESCRIPTION
* Migrate code to C++ (I don't want to deal with using `malloc` & `sprintf` to concatenate file paths...)
* Fixed an issue where the generated core dump is corrupted (ex: a core dump generated from `__simple_abort`)