### PR TITLE
Wait for the spawned shell child process

### DIFF
--- a/src/shellspawn/shellspawn.c
+++ b/src/shellspawn/shellspawn.c
@@ -113,6 +113,7 @@ void listenForConnections(void)
 		else
 		{
 			close(sock);
+ 			reapAll();
 		}
 	}
 }


### PR DESCRIPTION
The shell spawned in `shellspawn` is not properly waited for, resulting in multiple zombie processes of `mldr` after several calls to `darling shell`. This pull request adds a `reapAll()` call in the main process loop, ensuring that at most one zombie process of mldr remains.