### PR TITLE
(Syscall Redesign | Part 1) Relocate Syscall Source & Header To Legacy Path

### DIFF
--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/base.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/base.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/base.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-libelfloader.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-libelfloader.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/ext/for-libelfloader.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-libkqueue.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-libkqueue.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/ext/for-libkqueue.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-xtrace.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/for-xtrace.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/ext/for-xtrace.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/futex.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/ext/futex.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/ext/futex.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/legacy_path
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/legacy_path
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/legacy_path/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-arm64.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-arm64.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/linux-syscalls/linux-arm64.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-generic.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-generic.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/linux-syscalls/linux-generic.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-syscalls.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-syscalls.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/linux-syscalls/linux.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-x86.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-x86.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/linux-syscalls/linux-x86.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-x86_64.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux-x86_64.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/linux-syscalls/linux-x86_64.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/mman/duct_mman.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/mman/duct_mman.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/mman/duct_mman.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/signal/sigaltstack.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/signal/sigaltstack.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/signal/sigaltstack.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/simple.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/simple.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/simple.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/tsd.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/tsd.h
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/linux/tsd.h

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/mldr/elfcalls/dthreads.h
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/mldr/elfcalls/dthreads.h
@@ -1,0 +1,1 @@
+../../../../../../../../../../../src/startup/mldr/elfcalls/dthreads.h

--- a/src/frameworks/CoreServices/src/CarbonCore/FileManager.cpp
+++ b/src/frameworks/CoreServices/src/CarbonCore/FileManager.cpp
@@ -38,7 +38,7 @@ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <CarbonCore/DateTimeUtils.h>
 #include <errno.h>
-#include <ext/file_handle.h>
+#include <darling/emulation/legacy_path/ext/file_handle.h>
 
 #define STUB() // TODO
 

--- a/src/frameworks/CoreServices/src/FSEvents/FSEventsImpl.m
+++ b/src/frameworks/CoreServices/src/FSEvents/FSEventsImpl.m
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
-#include <ext/sys/inotify.h>
+#include <darling/emulation/legacy_path/ext/sys/inotify.h>
 
 static dispatch_queue_t g_fsEventsQueue = NULL;
 

--- a/src/frameworks/CoreServices/src/FSEvents/fseventsd.m
+++ b/src/frameworks/CoreServices/src/FSEvents/fseventsd.m
@@ -22,8 +22,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <ext/fanotify.h>
-#include <ext/file_handle.h>
+#include <darling/emulation/legacy_path/ext/fanotify.h>
+#include <darling/emulation/legacy_path/ext/file_handle.h>
 #include "./linux/fanotify.h"
 #include <dispatch/dispatch.h>
 #include <CoreServices/FileManager.h>

--- a/src/xtrace/bsd_trace.cpp
+++ b/src/xtrace/bsd_trace.cpp
@@ -1,4 +1,4 @@
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/src/xtrace/lock.h
+++ b/src/xtrace/lock.h
@@ -1,7 +1,7 @@
 #ifndef _XTRACE_LOCK_H_
 #define _XTRACE_LOCK_H_
 
-#include <darling/emulation/ext/futex.h>
+#include <darling/emulation/legacy_path/ext/futex.h>
 #include <stdint.h>
 
 #include "base.h"

--- a/src/xtrace/mach_trace.cpp
+++ b/src/xtrace/mach_trace.cpp
@@ -1,4 +1,4 @@
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include <unistd.h>
 #include <dlfcn.h>
 #include <mach/message.h>

--- a/src/xtrace/mig_trace.cpp
+++ b/src/xtrace/mig_trace.cpp
@@ -8,7 +8,7 @@
 
 #include <mach/mach.h>
 
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include "xtracelib.h"
 #include "mach_trace.h"
 #include "bsd_trace.h"

--- a/src/xtrace/posix_spawn_args.cpp
+++ b/src/xtrace/posix_spawn_args.cpp
@@ -7,7 +7,7 @@
 #include <sys/spawn_internal.h>
 #include <spawn_private.h>
 
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include "bsd_trace.h"
 
 #include "xtracelib.h"

--- a/src/xtrace/string.cpp
+++ b/src/xtrace/string.cpp
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <cstring>
 
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 
 //
 // Helper Functions

--- a/src/xtrace/tls.cpp
+++ b/src/xtrace/tls.cpp
@@ -1,9 +1,9 @@
 #include <stdlib.h>
-#include <darling/emulation/ext/for-xtrace.h>
+#include <darling/emulation/legacy_path/ext/for-xtrace.h>
 #include "tls.h"
 #include "memory.h"
 #include "lock.h"
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include <pthread/tsd_private.h>
 #include "xtracelib.h"
 
@@ -30,7 +30,7 @@ struct tls_table {
 // we have to use a slightly hackier technique: using one of the system's reserved but unused TLS keys; we use one from the range we currently reserve
 // for Darling.
 
-#include <darling/emulation/tsd.h>
+#include <darling/emulation/legacy_path/tsd.h>
 
 // TODO: also perform TLS cleanup for other threads when doing a fork
 

--- a/src/xtrace/xtracelib.cpp
+++ b/src/xtrace/xtracelib.cpp
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 #include "xtracelib.h"
 #include "mig_trace.h"
 #include "tls.h"
@@ -12,7 +12,7 @@
 #include "memory.h"
 #include <limits.h>
 
-#include <darling/emulation/ext/for-xtrace.h>
+#include <darling/emulation/legacy_path/ext/for-xtrace.h>
 #include <fcntl.h>
 #include <signal.h>
 

--- a/src/xtrace/xtracelib.h
+++ b/src/xtrace/xtracelib.h
@@ -1,7 +1,7 @@
 #ifndef _XTRACELIB_H_
 #define _XTRACELIB_H_
 #include <stdint.h>
-#include <darling/emulation/simple.h>
+#include <darling/emulation/legacy_path/simple.h>
 
 #include "base.h"
 #include "string.h"


### PR DESCRIPTION
To help make this effort easier for me. I split my syscall redesign task into multiple parts.

The first step is set up a `src` and `include` folder to store the source code and header files. For the time being, all of these files are under the `legacy_path` folder.