### PR TITLE
(Syscall Redesign | Part 2) Organize Syscall Source & Header Files

### DIFF
--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/common
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/common
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/common/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/conversion
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/conversion
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/conversion/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/legacy_path
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/legacy_path
@@ -1,1 +1,0 @@
-../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/legacy_path/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux_premigration
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/linux_premigration
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/linux_premigration/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/other
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/other
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/other/

--- a/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/xnu_syscall
+++ b/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/darling/emulation/xnu_syscall
@@ -1,0 +1,1 @@
+../../../../../../../../../../src/external/xnu/darling/src/libsystem_kernel/emulation/include/xnu_syscall/

--- a/src/frameworks/CoreServices/src/CarbonCore/FileManager.cpp
+++ b/src/frameworks/CoreServices/src/CarbonCore/FileManager.cpp
@@ -38,7 +38,7 @@ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <CarbonCore/DateTimeUtils.h>
 #include <errno.h>
-#include <darling/emulation/legacy_path/ext/file_handle.h>
+#include <darling/emulation/linux_premigration/ext/file_handle.h>
 
 #define STUB() // TODO
 

--- a/src/frameworks/CoreServices/src/FSEvents/FSEventsImpl.m
+++ b/src/frameworks/CoreServices/src/FSEvents/FSEventsImpl.m
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
-#include <darling/emulation/legacy_path/ext/sys/inotify.h>
+#include <darling/emulation/linux_premigration/ext/sys/inotify.h>
 
 static dispatch_queue_t g_fsEventsQueue = NULL;
 

--- a/src/frameworks/CoreServices/src/FSEvents/fseventsd.m
+++ b/src/frameworks/CoreServices/src/FSEvents/fseventsd.m
@@ -22,8 +22,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <darling/emulation/legacy_path/ext/fanotify.h>
-#include <darling/emulation/legacy_path/ext/file_handle.h>
+#include <darling/emulation/linux_premigration/ext/fanotify.h>
+#include <darling/emulation/linux_premigration/ext/file_handle.h>
 #include "./linux/fanotify.h"
 #include <dispatch/dispatch.h>
 #include <CoreServices/FileManager.h>

--- a/src/xtrace/bsd_trace.cpp
+++ b/src/xtrace/bsd_trace.cpp
@@ -1,4 +1,4 @@
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/src/xtrace/lock.h
+++ b/src/xtrace/lock.h
@@ -1,7 +1,7 @@
 #ifndef _XTRACE_LOCK_H_
 #define _XTRACE_LOCK_H_
 
-#include <darling/emulation/legacy_path/ext/futex.h>
+#include <darling/emulation/linux_premigration/ext/futex.h>
 #include <stdint.h>
 
 #include "base.h"

--- a/src/xtrace/mach_trace.cpp
+++ b/src/xtrace/mach_trace.cpp
@@ -1,4 +1,4 @@
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include <unistd.h>
 #include <dlfcn.h>
 #include <mach/message.h>

--- a/src/xtrace/mig_trace.cpp
+++ b/src/xtrace/mig_trace.cpp
@@ -8,7 +8,7 @@
 
 #include <mach/mach.h>
 
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include "xtracelib.h"
 #include "mach_trace.h"
 #include "bsd_trace.h"

--- a/src/xtrace/posix_spawn_args.cpp
+++ b/src/xtrace/posix_spawn_args.cpp
@@ -7,7 +7,7 @@
 #include <sys/spawn_internal.h>
 #include <spawn_private.h>
 
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include "bsd_trace.h"
 
 #include "xtracelib.h"

--- a/src/xtrace/string.cpp
+++ b/src/xtrace/string.cpp
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <cstring>
 
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 
 //
 // Helper Functions

--- a/src/xtrace/tls.cpp
+++ b/src/xtrace/tls.cpp
@@ -1,9 +1,9 @@
 #include <stdlib.h>
-#include <darling/emulation/legacy_path/ext/for-xtrace.h>
+#include <darling/emulation/linux_premigration/ext/for-xtrace.h>
 #include "tls.h"
 #include "memory.h"
 #include "lock.h"
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include <pthread/tsd_private.h>
 #include "xtracelib.h"
 
@@ -30,7 +30,7 @@ struct tls_table {
 // we have to use a slightly hackier technique: using one of the system's reserved but unused TLS keys; we use one from the range we currently reserve
 // for Darling.
 
-#include <darling/emulation/legacy_path/tsd.h>
+#include <darling/emulation/common/tsd.h>
 
 // TODO: also perform TLS cleanup for other threads when doing a fork
 

--- a/src/xtrace/xtracelib.cpp
+++ b/src/xtrace/xtracelib.cpp
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 #include "xtracelib.h"
 #include "mig_trace.h"
 #include "tls.h"
@@ -12,7 +12,7 @@
 #include "memory.h"
 #include <limits.h>
 
-#include <darling/emulation/legacy_path/ext/for-xtrace.h>
+#include <darling/emulation/linux_premigration/ext/for-xtrace.h>
 #include <fcntl.h>
 #include <signal.h>
 

--- a/src/xtrace/xtracelib.h
+++ b/src/xtrace/xtracelib.h
@@ -1,7 +1,7 @@
 #ifndef _XTRACELIB_H_
 #define _XTRACELIB_H_
 #include <stdint.h>
-#include <darling/emulation/legacy_path/simple.h>
+#include <darling/emulation/common/simple.h>
 
 #include "base.h"
 #include "string.h"


### PR DESCRIPTION
This PR focuses on organizing the syscall source & header files into the following location:
* `common` - Source code that is intended to be used everywhere
* `conversion` - Contain methods that convert values between a XNU & Linux variable.
* `linux_premigration` - A temporary folder that contains Linux syscalls. This folder will be removed once we are able to do the #944 migration
* `other` - Other source files (mainly the sources that would stay in the `darling-xnu` repo after the #944 migration)
* `xnu_syscall` - Contains re-implementations of XNU syscalls 