### PR TITLE
Update darling stub generator to use up to date copyright header

### DIFF
--- a/tools/darling-stub-gen
+++ b/tools/darling-stub-gen
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess, re, getpass
+import sys, os, subprocess, re, getpass, datetime
 
 # Data
 library = False
@@ -20,10 +20,10 @@ private_framework_prefix = "/System/Library/PrivateFrameworks/"
 username = getpass.getuser()
 class_dump = "/Users/" + username + "/bin/class-dump"
 
-copyright = """/*
+copyright_template = """/*
  This file is part of Darling.
 
- Copyright (C) 2019 Lubos Dolezel
+ Copyright (C) {} Darling Developers
 
  Darling is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ copyright = """/*
 */
 
 """
+copyright = copyright_template.format(datetime.datetime.now(datetime.timezone.utc).year)
 
 c_func_impl_stub = """
 void* %s(void)


### PR DESCRIPTION
This updates the copyright header written out by the darling stub generator to be up to date like in [generate-xcode-stubs.py](https://github.com/darlinghq/darling/blob/master/tools/generate-xcode-stubs.py)