### PR TITLE
Add symbols for SubEthaEdit app

### DIFF
--- a/src/frameworks/SystemConfiguration/SCSchemaDefinitions.c
+++ b/src/frameworks/SystemConfiguration/SCSchemaDefinitions.c
@@ -1,33 +1,31 @@
 #include <SystemConfiguration/SCSchemaDefinitions.h>
 #include <CoreFoundation/CFString.h>
 
-#ifndef CONST_STRING_DECL
-#	define CONST_STRING_DECL(name, value) const CFStringRef name = CFSTR(value)
-#endif
-
-CONST_STRING_DECL(kSCPropNetProxiesExceptionsList, "ExceptionsList");
-CONST_STRING_DECL(kSCPropNetProxiesExcludeSimpleHostnames, "ExcludeSimpleHostnames");
-CONST_STRING_DECL(kSCPropNetProxiesFTPEnable, "FTPEnable");
-CONST_STRING_DECL(kSCPropNetProxiesFTPPassive, "FTPPassive");
-CONST_STRING_DECL(kSCPropNetProxiesFTPPort, "FTPPort");
-CONST_STRING_DECL(kSCPropNetProxiesFTPProxy, "FTPProxy");
-CONST_STRING_DECL(kSCPropNetProxiesGopherEnable, "GopherEnable");
-CONST_STRING_DECL(kSCPropNetProxiesGopherPort, "GopherPort");
-CONST_STRING_DECL(kSCPropNetProxiesGopherProxy, "GopherProxy");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPEnable, "HTTPEnable");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPPort, "HTTPPort");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPProxy, "HTTPProxy");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPSEnable, "HTTPSEnable");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPSPort, "HTTPSPort");
-CONST_STRING_DECL(kSCPropNetProxiesHTTPSProxy, "HTTPSProxy");
-CONST_STRING_DECL(kSCPropNetProxiesRTSPEnable, "RTSPEnable");
-CONST_STRING_DECL(kSCPropNetProxiesRTSPPort, "RTSPPort");
-CONST_STRING_DECL(kSCPropNetProxiesRTSPProxy, "RTSPProxy");
-CONST_STRING_DECL(kSCPropNetProxiesSOCKSEnable, "SOCKSEnable");
-CONST_STRING_DECL(kSCPropNetProxiesSOCKSPort, "SOCKSPort");
-CONST_STRING_DECL(kSCPropNetProxiesSOCKSProxy, "SOCKSProxy");
-CONST_STRING_DECL(kSCPropNetProxiesProxyAutoConfigEnable, "ProxyAutoConfigEnable");
-CONST_STRING_DECL(kSCPropNetProxiesProxyAutoConfigJavaScript, "ProxyAutoConfigJavaScript");
-CONST_STRING_DECL(kSCPropNetProxiesProxyAutoConfigURLString, "ProxyAutoConfigURLString");
-CONST_STRING_DECL(kSCPropNetProxiesProxyAutoDiscoveryEnable, "ProxyAutoDiscoveryEnable");
-
+const CFStringRef kSCPropNetIPv4Addresses = CFSTR("Addresses");
+const CFStringRef kSCPropNetIPv4SubnetMasks = CFSTR("SubnetMasks");
+const CFStringRef kSCPropNetProxiesExceptionsList = CFSTR("ExceptionsList");
+const CFStringRef kSCPropNetProxiesExcludeSimpleHostnames = CFSTR("ExcludeSimpleHostnames");
+const CFStringRef kSCPropNetProxiesFTPEnable = CFSTR("FTPEnable");
+const CFStringRef kSCPropNetProxiesFTPPassive = CFSTR("FTPPassive");
+const CFStringRef kSCPropNetProxiesFTPPort = CFSTR("FTPPort");
+const CFStringRef kSCPropNetProxiesFTPProxy = CFSTR("FTPProxy");
+const CFStringRef kSCPropNetProxiesGopherEnable = CFSTR("GopherEnable");
+const CFStringRef kSCPropNetProxiesGopherPort = CFSTR("GopherPort");
+const CFStringRef kSCPropNetProxiesGopherProxy = CFSTR("GopherProxy");
+const CFStringRef kSCPropNetProxiesHTTPEnable = CFSTR("HTTPEnable");
+const CFStringRef kSCPropNetProxiesHTTPPort = CFSTR("HTTPPort");
+const CFStringRef kSCPropNetProxiesHTTPProxy = CFSTR("HTTPProxy");
+const CFStringRef kSCPropNetProxiesHTTPSEnable = CFSTR("HTTPSEnable");
+const CFStringRef kSCPropNetProxiesHTTPSPort = CFSTR("HTTPSPort");
+const CFStringRef kSCPropNetProxiesHTTPSProxy = CFSTR("HTTPSProxy");
+const CFStringRef kSCPropNetProxiesRTSPEnable = CFSTR("RTSPEnable");
+const CFStringRef kSCPropNetProxiesRTSPPort = CFSTR("RTSPPort");
+const CFStringRef kSCPropNetProxiesRTSPProxy = CFSTR("RTSPProxy");
+const CFStringRef kSCPropNetProxiesSOCKSEnable = CFSTR("SOCKSEnable");
+const CFStringRef kSCPropNetProxiesSOCKSPort = CFSTR("SOCKSPort");
+const CFStringRef kSCPropNetProxiesSOCKSProxy = CFSTR("SOCKSProxy");
+const CFStringRef kSCPropNetProxiesProxyAutoConfigEnable = CFSTR("ProxyAutoConfigEnable");
+const CFStringRef kSCPropNetProxiesProxyAutoConfigJavaScript = CFSTR("ProxyAutoConfigJavaScript");
+const CFStringRef kSCPropNetProxiesProxyAutoConfigURLString = CFSTR("ProxyAutoConfigURLString");
+const CFStringRef kSCPropNetProxiesProxyAutoDiscoveryEnable = CFSTR("ProxyAutoDiscoveryEnable");
+const CFStringRef kSCDynamicStorePropNetPrimaryInterface = CFSTR("PrimaryInterface");

--- a/src/frameworks/WebKit/CMakeLists.txt
+++ b/src/frameworks/WebKit/CMakeLists.txt
@@ -47,6 +47,7 @@ add_framework(WebKit
         src/_WKWebsiteDataStore.m
         src/_WKWebsiteDataStoreConfiguration.m
         src/_WKWebsitePolicies.m
+        src/WebView.m
         src/WKCustomProtocolLoader.m
         src/WKCustomProtocol.m
         src/WKNetworkSessionDelegate.m

--- a/src/frameworks/WebKit/include/WebKit/WebKit.h
+++ b/src/frameworks/WebKit/include/WebKit/WebKit.h
@@ -188,6 +188,7 @@
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWindowFeatures.h>
+#import <WebKit/WebView.h>
 
 @protocol DOMEventListener
 @end

--- a/src/frameworks/WebKit/include/WebKit/WebView.h
+++ b/src/frameworks/WebKit/include/WebKit/WebView.h
@@ -1,0 +1,6 @@
+#import <Cocoa/Cocoa.h>
+
+extern NSString *WebElementImageKey;
+extern NSString *WebElementLinkURLKey;
+extern NSString *WebElementLinkTargetFrameKey;
+extern NSString *WebElementLinkTitleKey;

--- a/src/frameworks/WebKit/src/WebView.m
+++ b/src/frameworks/WebKit/src/WebView.m
@@ -1,0 +1,6 @@
+#import <WebKit/WebView.h>
+
+NSString *WebElementImageKey = @"WebElementImage";
+NSString *WebElementLinkURLKey = @"WebElementLinkURL";
+NSString *WebElementLinkTargetFrameKey = @"WebElementTargetFrame";
+NSString *WebElementLinkTitleKey = @"WebElementLinkTitle";


### PR DESCRIPTION
This is the first symbols addition to make SubEthaEdit work. (two other additions are needed, but in other repositories).
It will not open, but it stuck at an implementation error, not symbol lack.

<details open><summary>Symbols added</summary>
<p>

- System Configuration
  - `_kSCDynamicStorePropNetPrimaryInterface` ([docs](https://developer.apple.com/documentation/webkit/webelementimagekey?language=objc)) ([value](https://github.com/darlinghq/darling-configd/blob/master/SystemConfiguration.fproj/SCSchemaDefinitions.c#L494))
  - `_kSCPropNetIPv4Addresses` ([docs](https://developer.apple.com/documentation/webkit/webelementimagekey?language=objc)) ([value](https://github.com/darlinghq/darling-configd/blob/master/SystemConfiguration.fproj/SCSchemaDefinitions.c#L190))
  - `_kSCPropNetIPv4SubnetMasks` ([docs](https://developer.apple.com/documentation/webkit/webelementimagekey?language=objc)) ([value](https://github.com/darlinghq/darling-configd/blob/master/SystemConfiguration.fproj/SCSchemaDefinitions.c#L194))
- WebKit
  - `_WebElementImageKey` ([docs](https://developer.apple.com/documentation/webkit/webelementimagekey?language=objc))
  - `_WebElementLinkURLKey` ([docs](https://developer.apple.com/documentation/webkit/webelementlinkurlkey?language=objc))
  - `_WebElementLinkTargetFrameKey` ([docs](https://developer.apple.com/documentation/webkit/webelementlinktargetframekey?language=objc))
  - `_WebElementLinkTitleKey` ([docs](https://developer.apple.com/documentation/webkit/webelementkinktitlekey?language=objc))

</p>
</details> 

Fixes: #1512 and #1333 (the latter only add missing symbol)
**Observation:** I've removed `CONST_STRING_DECL` definition to be consistent with other files
