### PR TITLE
CMake protect PATH in dSYM generation

### DIFF
--- a/cmake/dsym.cmake
+++ b/cmake/dsym.cmake
@@ -12,7 +12,7 @@ function(dsym target)
 	if (DSYMUTIL_EXE AND build_type MATCHES debug)
 
 		add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${target}.dSYM" DEPENDS "${target}" COMMAND ${CMAKE_COMMAND} -E env
-			"PATH=${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/misc:$ENV{PATH}"
+			"PATH='${CMAKE_BINARY_DIR}/src/external/cctools-port/cctools/misc:$ENV{PATH}'"
 			"${DSYMUTIL_EXE}" "-flat" "-o" "${target}.dSYM" "$<TARGET_FILE:${target}>")
 
 		add_custom_target("${target}-dSYM" ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${target}.dSYM" getuuid lipo)


### PR DESCRIPTION
Fix special characters in path
```
Generating system_firstpass.dSYM
/bin/sh: -c: line 1: syntax error near unexpected token `('
/bin/sh: -c: line 1: `cd /mnt/data/git/darling/cmake-build-x64-clang-debug/src/external/libsystem && /opt/clion/bin/cmake/linux/x64/bin/cmake -E env PATH=/mnt/data/git/darling/cmake-build-x64-clang-debug/src/external/cctools-port/cctools/misc:/mnt/data/.data/android/sdk/emulator:/home/marin/.wine/drive_c/Program\ Files\ (x86)/SCE/ORBIS\ SDKs/8.000/host_tools/bin:/mnt/data/Emu/PS4/bin:/home/marin/install/bin:/mnt/data/.data/android/sdk/emulator:/home/marin/.wine/drive_c/Program\ Files\ (x86)/SCE/ORBIS\ SDKs/8.000/host_tools/bin:/mnt/data/Emu/PS4/bin:/home/marin/install/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/lib/rustup/bin:/opt/clion/bin/ninja/linux/x64 /home/marin/install/bin/dsymutil -flat -o system_firstpass.dSYM /mnt/data/git/darling/cmake-build-x64-clang-debug/src/external/libsystem/libsystem_firstpass.dylib'
make[3]: *** [src/external/libsystem/CMakeFiles/system_firstpass-dSYM.dir/build.make:75: src/external/libsystem/system_firstpass.dSYM] Error 2
make[2]: *** [CMakeFiles/Makefile2:33953: src/external/libsystem/CMakeFiles/system_firstpass-dSYM.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:33960: src/external/libsystem/CMakeFiles/system_firstpass-dSYM.dir/rule] Error 2
make: *** [Makefile:4524: system_firstpass-dSYM] Error 2
```