### PR TITLE
Add implementation for LAContext

### DIFF
--- a/src/frameworks/LocalAuthentication/CMakeLists.txt
+++ b/src/frameworks/LocalAuthentication/CMakeLists.txt
@@ -27,8 +27,10 @@ add_framework(LocalAuthentication
 
 	SOURCES
 		src/LACFSupport.c
+		src/LAContext.m
 		src/stubs.c
 
 	DEPENDENCIES
 		system
+		Foundation
 )

--- a/src/frameworks/LocalAuthentication/src/LAContext.m
+++ b/src/frameworks/LocalAuthentication/src/LAContext.m
@@ -1,0 +1,37 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2025 Darling Developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <LocalAuthentication/LAContext.h>
+
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
+
+@implementation LAContext
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end


### PR DESCRIPTION
Adds implementation of `LAContext` needed for iTerm2