### PR TITLE
Use built-in sqrt functions

### DIFF
--- a/src/libm/Source/Intel/xmm_sqrt.c
+++ b/src/libm/Source/Intel/xmm_sqrt.c
@@ -5,6 +5,9 @@
  *  Created by Ian Ollmann, Ph.D. on 7/14/05.
  *  Copyright © 2005 Apple Computer, Inc. All rights reserved.
  *
+ *  Modified by Marin Baron, on 30/11/25
+ *  As part of the Darling project.
+ *
  *  This set of functions may seem a little silly at first. The compiler can generate
  *  sqrtsd or sqrtsf inline, so why do we need a function? It appears that people can 
  *  make a function pointer to sqrt and call that. Therefore an implementation of sqrt()
@@ -16,17 +19,13 @@
 #include "math.h"
 
 double sqrt( double x )
-{
-    xDouble f = DOUBLE_2_XDOUBLE( x );
-    f = _MM_SQRT_SD(f);           
-    return XDOUBLE_2_DOUBLE( f );
+{      
+    return __builtin_sqrt( x );
 }
 
 float sqrtf( float x )
 {
-    xFloat f = FLOAT_2_XFLOAT( x );
-    f = _mm_sqrt_ss(f);
-    return XFLOAT_2_FLOAT( f );
+    return __builtin_sqrtf( x );
 }
 
 


### PR DESCRIPTION
Latest LLVM 22.x has removed __builtin_ia32_sqrtsd https://github.com/llvm/llvm-project/pull/165682#issuecomment-3592475382