### PR TITLE
Implement function to verify if data is UINibArchive

### DIFF
--- a/src/private-frameworks/UIFoundation/include/UIFoundation/UIFoundation.h
+++ b/src/private-frameworks/UIFoundation/include/UIFoundation/UIFoundation.h
@@ -139,6 +139,10 @@
 #import <UIFoundation/NSWordMLReader.h>
 #import <UIFoundation/NSWordMLWriter.h>
 
+extern const char UIArchiveHeaderIdentifier[];
+extern const uint32_t UIMaximumCompatibleFormatVersion;
+extern const uint32_t UICurrentCoderVersion;
+
 void* CFArrayCreateWithNonRetainedObjectsFromNSArray(void);
 void* CFDictionaryCreateWithNonRetainedValuesFromNSDictionary(void);
 void* NSConvertGlyphsToPackedGlyphs(void);
@@ -150,7 +154,7 @@ void* UIAppendBytesForValueToData(void);
 void* UIAppendVInt32ToData(void);
 void* UIArrayByKeepingObjectsInSet(void);
 void* UICreateOrderedAndStrippedCoderValues(void);
-void* UIDataLooksLikeNibArchive(void);
+BOOL UIDataLooksLikeNibArchive(NSData *data);
 void* UIDistanceBetweenPointAndRect(void);
 void* UIFixedByteLengthForType(void);
 void* UINibArchiveIndexFromNumber(void);

--- a/src/private-frameworks/UIFoundation/include/UIFoundation/UINibDecoder.h
+++ b/src/private-frameworks/UIFoundation/include/UIFoundation/UINibDecoder.h
@@ -19,6 +19,8 @@
 
 #include <Foundation/Foundation.h>
 
-@interface UINibDecoder : NSObject
+@interface UINibDecoder : NSCoder
+
+- (instancetype) initForReadingWithData: (NSData *) data;
 
 @end

--- a/src/private-frameworks/UIFoundation/src/UIFoundation.m
+++ b/src/private-frameworks/UIFoundation/src/UIFoundation.m
@@ -17,10 +17,13 @@
  along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #include <UIFoundation/UIFoundation.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+const char UIArchiveHeaderIdentifier[] = "NIBArchive";
+const uint32_t UIMaximumCompatibleFormatVersion = 1;
+const uint32_t UICurrentCoderVersion = 10;
 
 static int verbose = 0;
 
@@ -95,10 +98,21 @@ void* UICreateOrderedAndStrippedCoderValues(void)
     return NULL;
 }
 
-void* UIDataLooksLikeNibArchive(void)
+BOOL UIDataLooksLikeNibArchive(NSData *data)
 {
-    if (verbose) puts("STUB: UIDataLooksLikeNibArchive called");
-    return NULL;
+    const size_t minimum_size = sizeof(UIArchiveHeaderIdentifier) - 1;
+
+    if (data.length < minimum_size) {
+        return NO;
+    }
+
+    const uint8_t *bytes = data.bytes;
+
+    if (memcmp(bytes, UIArchiveHeaderIdentifier, minimum_size) != 0) {
+        return NO;
+    }
+
+    return YES;
 }
 
 void* UIDistanceBetweenPointAndRect(void)

--- a/src/private-frameworks/UIFoundation/src/UINibDecoder.m
+++ b/src/private-frameworks/UIFoundation/src/UINibDecoder.m
@@ -21,14 +21,81 @@
 
 @implementation UINibDecoder
 
-- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+- (instancetype) initForReadingWithData: (NSData *) data
 {
-    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return self;
 }
 
-- (void)forwardInvocation:(NSInvocation *)anInvocation
+- (BOOL) containsValueForKey: (NSString *) key
 {
-    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return NO;
+}
+
+- (void) decodeValueOfObjCType: (const char *) type at: (void *) data
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+}
+
+- (NSData *) decodeDataObject
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return nil;
+}
+
+- (id) decodeObjectForKey: (NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return nil;
+}
+
+- (BOOL) decodeBoolForKey: (NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return NO;
+}
+
+- (int) decodeIntForKey:(NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0;
+}
+
+- (int32_t) decodeInt32ForKey:(NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0;
+}
+
+- (int64_t) decodeInt64ForKey:(NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0;
+}
+
+- (float) decodeFloatForKey:(NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0.0f;
+}
+
+- (double) decodeDoubleForKey:(NSString *) key
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0.0;
+}
+
+- (const uint8_t *) decodeBytesForKey: (NSString *) key returnedLength: (NSUInteger *) len
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return NULL;
+}
+
+- (NSInteger) versionForClassName: (NSString *) className
+{
+    printf("STUB %s\n", __PRETTY_FUNCTION__);
+    return 0;
 }
 
 @end


### PR DESCRIPTION
As can be seen [here](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes#Interface-Builder), XIB files is now compiled using UINibEncoder to reduce file size and that new NIB files are structured following this [format](https://www.mothersruin.com/software/Archaeology/reverse/uinib.html).