### PR TITLE
added CMakeLists.txt defines up to Clang 23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ if (NOT DEFINED CMAKE_C_COMPILER)
 		"clang-13"
 		"clang-14"
 		"clang-15"
+		"clang-16"
+		"clang-17"
+		"clang-18"
+		"clang-19"
+		"clang-20"
+		"clang-21"
+		"clang-22"
+		"clang-23"
 )
 endif(NOT DEFINED CMAKE_C_COMPILER)
 
@@ -33,6 +41,14 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 		"clang++-13"
 		"clang++-14"
 		"clang++-15"
+		"clang++-16"
+		"clang++-17"
+		"clang++-18"
+		"clang++-19"
+		"clang++-20"
+		"clang++-21"
+		"clang++-22"
+		"clang++-23"
 )
 endif(NOT DEFINED CMAKE_CXX_COMPILER)
 


### PR DESCRIPTION
At the time of this writing, LLVM 21 is out, with LLVM 22 scheduled to be released later this month. This minor change updates the `CMakeLists.txt` file to include all variants up to`Clang-23` (scheduled for release in August). Hypothetically this should ensure that Darling supports all Clang versions bundled with every Linux distro scheduled to be released this year. Notably that includes Ubuntu 26.04 LTS (and all of its derivatives). 

Bumping the supported Clang version was necessary for me to build on Pop!_OS 24.04 (an Ubuntu derivative that was actually released a couple months back). 