### PR TITLE
Improve source archive compression in GitHub Actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -73,8 +73,8 @@ jobs:
     - name: Compress source
       run: |
         mkdir -v archive
-        tar --create --gzip --verbose \
-            --file archive/darling-source.tar.gz \
+        tar --create --use-compress-program="xz -9e" --verbose \
+            --file archive/darling-source.tar.xz \
             --exclude=.git --exclude=.gitmodules --exclude=.gitignore \
             --directory=source \
             darling


### PR DESCRIPTION
- Switch compression format from gzip to xz
- Use xz maximum compression level (`-9e`) to minimize archive size

| Compression Format | Compression Level | Size |
| --- | --- | --- |
| gzip | default (`-6`) | 768 MiB |
| gzip | maximum (`-9`) | 760 MiB |
| xz | maximum (`-9e`) | 486 MiB |

The results show xz with maximum compression level cuts the archive size by ~37%.