### PR TITLE
Add Link To Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: darlinghq


### PR DESCRIPTION
~~Will be merged once our Open Collective page is ready to accept donations.~~

We'll enable the sponsor button after our open page is able to accept donations.

---

@bugaevc & @LubosD, there is [a setting that needs to be enabled to show the sponsor button](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository).

I don't have the permissions to verify if this is already set in this repo. You can find this setting under the general tab.

<img width="769" height="200" alt="image" src="https://github.com/user-attachments/assets/4c8c7c1b-e615-4ae7-83c7-17b0855b42d5" />
