### PR TITLE
Add `Info.plist` file for CoreServices sub-frameworks

### DIFF
--- a/src/frameworks/CoreServices/Info.plist
+++ b/src/frameworks/CoreServices/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.apple.CoreServices</string>
+	<key>CFBundleExecutable</key>
+    <string>CoreServices</string>
+	<key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1226</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/src/frameworks/CoreServices/src/CarbonCore/CMakeLists.txt
+++ b/src/frameworks/CoreServices/src/CarbonCore/CMakeLists.txt
@@ -50,6 +50,8 @@ add_framework(CarbonCore
 
 	SOURCES 
 		${CarbonCore_SRCS}
+	RESOURCES
+		Info.plist Info.plist
 	
 	DEPENDENCIES
 		CoreFoundation

--- a/src/frameworks/CoreServices/src/CarbonCore/Info.plist
+++ b/src/frameworks/CoreServices/src/CarbonCore/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.CoreServices.CarbonCore</string>
+    <key>CFBundleName</key>
+    <string>Carbon Core</string>
+    <key>CFBundleExecutable</key>
+    <string>CarbonCore</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1333</string>
+</dict>
+</plist>

--- a/src/frameworks/CoreServices/src/DictionaryServices/CMakeLists.txt
+++ b/src/frameworks/CoreServices/src/DictionaryServices/CMakeLists.txt
@@ -15,6 +15,8 @@ add_framework(DictionaryServices
 
 	SOURCES
 		empty.c
+	RESOURCES
+		Info.plist Info.plist
 
 	DEPENDENCIES
 		CoreFoundation

--- a/src/frameworks/CoreServices/src/DictionaryServices/Info.plist
+++ b/src/frameworks/CoreServices/src/DictionaryServices/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.DictionaryServices</string>
+    <key>CFBundleName</key>
+    <string>DictionaryServices</string>
+    <key>CFBundleExecutable</key>
+    <string>DictionaryServices</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>382</string>
+</dict>
+</plist>

--- a/src/frameworks/CoreServices/src/Metadata/CMakeLists.txt
+++ b/src/frameworks/CoreServices/src/Metadata/CMakeLists.txt
@@ -16,6 +16,8 @@ add_framework(Metadata
 	SOURCES
 		MDQuery.c
 		MDItem.c
+	RESOURCES
+		Info.plist Info.plist
 
 	DEPENDENCIES
 		CoreFoundation

--- a/src/frameworks/CoreServices/src/Metadata/Info.plist
+++ b/src/frameworks/CoreServices/src/Metadata/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.Metadata</string>
+    <key>CFBundleName</key>
+    <string>Metadata</string>
+    <key>CFBundleExecutable</key>
+    <string>Metadata</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>2418.5.9.101</string>
+</dict>
+</plist>

--- a/src/frameworks/CoreServices/src/SearchKit/CMakeLists.txt
+++ b/src/frameworks/CoreServices/src/SearchKit/CMakeLists.txt
@@ -15,6 +15,8 @@ add_framework(SearchKit
 	SOURCES
 		SKAnalysis.c
 		SKIndex.c
+	RESOURCES
+		Info.plist Info.plist
 
 	DEPENDENCIES
 		CoreFoundation

--- a/src/frameworks/CoreServices/src/SearchKit/Info.plist
+++ b/src/frameworks/CoreServices/src/SearchKit/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.SearchKit</string>
+    <key>CFBundleName</key>
+    <string>SearchKit</string>
+    <key>CFBundleExecutable</key>
+    <string>SearchKit</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1.4.2</string>
+</dict>
+</plist>


### PR DESCRIPTION
Without this, these frameworks could not be found by identifier using [CFBundleGetBundleWithIdentifier](https://developer.apple.com/documentation/corefoundation/cfbundlegetbundlewithidentifier(_:)?language=objc). I added other CFBundle* properties to CoreServices' Info.plist to make it the same as the others.
It improves the execution of applications that use [PyObjC](https://pyobjc.readthedocs.io/en/latest/) like Google's Backup and Sync (https://github.com/darlinghq/darling/issues/342).