### PR TITLE
Add source file and fix header build

### DIFF
--- a/src/frameworks/Carbon/HIToolbox/CMakeLists.txt
+++ b/src/frameworks/Carbon/HIToolbox/CMakeLists.txt
@@ -21,6 +21,7 @@ add_framework(HIToolbox
 		src/Keyboards.cpp
 		src/Events.cpp
 		src/CarbonEventsCore.c
+		src/CarbonEvents.c
 		src/MacApplication.cpp
 		src/MacWindows.cpp
 		src/TextInputSources.mm

--- a/src/frameworks/Carbon/HIToolbox/include/HIToolbox/CarbonEvents.h
+++ b/src/frameworks/Carbon/HIToolbox/include/HIToolbox/CarbonEvents.h
@@ -22,6 +22,7 @@
 
 #include <CoreFoundation/CFBase.h>
 #include <CoreServices/MacTypes.h>
+#include <HIToolbox/CarbonEventsCore.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The source file was missing from the build in #1760, so it wasn't compiled and an error in the header went unnoticed.

This PR adds the missing file to the build and fixes the header error.
